### PR TITLE
Fix leading `{` not rendering in preview code blocks on WebKit

### DIFF
--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -2103,6 +2103,7 @@ body {
   margin: 1.2em 0;
   border: 1px solid var(--border);
   tab-size: 4;
+  hanging-punctuation: none;
 }
 
 #preview-pane pre .code-copy-btn {


### PR DESCRIPTION
## Summary

- `.preview-page` sets `hanging-punctuation: first allow-end last`, which cascades to descendant `<pre>` elements.
- WebKit (Tauri/macOS) honors `hanging-punctuation`, so an opening punctuation character (`{`, `(`, `[`, `「`, …) at the start of a code block is hung outside the `<pre>` padding and clipped — only that one character disappears visually, while the underlying text (and copy) is unaffected.
- Add `hanging-punctuation: none` to `#preview-pane pre` so code blocks render verbatim, while body text keeps the hanging-punctuation effect.

Fixes #209.

Thanks to @sinofseven for the detailed root-cause analysis and fix direction.

## Test plan

- [ ] Open the editor on macOS (Tauri / WebKit) and verify the example from the issue:
  ````
  ```javascript
  {foo: "bar"}
  ```
  ````
  Preview should show the leading `{`.
- [ ] Confirm body-text punctuation hanging still works for regular paragraphs.
- [ ] No regression in other code-block styling (border, padding, copy button position).