### PR TITLE
Fix MCP sidecar bundling: rebuild to 0.1.3 and build from source in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,13 @@ jobs:
       - name: Install frontend dependencies
         run: cd ui && npm ci
 
+      - name: Build MCP sidecar
+        run: |
+          cargo build -p markupsidedown-mcp --release --target aarch64-apple-darwin
+          cp target/aarch64-apple-darwin/release/markupsidedown-mcp \
+             src-tauri/binaries/markupsidedown-mcp-aarch64-apple-darwin
+          ./src-tauri/binaries/markupsidedown-mcp-aarch64-apple-darwin --version
+
       - name: Get version
         id: version
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Closes #232

## Summary

- Rebuild the committed MCP sidecar (`src-tauri/binaries/markupsidedown-mcp-aarch64-apple-darwin`) to **0.1.3** so v0.2.22 ships the fix from `6e5863e` (extract_json/crawl_website failing when `response_format` is an object).
- Add a CI step that builds the MCP sidecar from source before `tauri-action` runs, so future releases can never silently regress on a stale committed binary.

## Background

The release DMGs for **v0.2.18 – v0.2.21** all bundle the **0.1.2** MCP binary even though source has been on 0.1.3 since 2026-04-27. Cause:

- Tauri's `externalBin: ["binaries/markupsidedown-mcp"]` consumes whatever is at `src-tauri/binaries/markupsidedown-mcp-<target>` at build time.
- That file was a hand-committed pre-built binary, last updated 2026-04-02 (`6c0a1a4` "bump MCP server version to 0.1.2").
- The fix commit `6e5863e` bumped `mcp-server-rs/Cargo.toml` to 0.1.3 but did not rebuild & commit the sidecar.
- The release workflow only ran `tauri-action` and never rebuilt `mcp-server-rs`, so every subsequent tag re-shipped the stale 0.1.2 binary.

User-visible symptom: Claude Code / other MCP clients hit `error decoding response body` on `extract_json` and `crawl_website` calls that pass `response_format`.

## Verification

- Local `cargo build -p markupsidedown-mcp --release --target aarch64-apple-darwin` produces a binary reporting `markupsidedown-mcp 0.1.3`.
- Smoke-tested via JSON-RPC stdin: `extract_json` against `example.com` with a `response_format` object now returns `{"title":"Example Domain"}` instead of erroring.

## Test plan

- [ ] Merge, then push tag `v0.2.22` to trigger the release workflow.
- [ ] Verify the new `Build MCP sidecar` step succeeds in the workflow run.
- [ ] Download `MarkUpsideDown_0.2.22_aarch64.dmg` and confirm its bundled `markupsidedown-mcp --version` reports `0.1.3`.
- [ ] In Claude Code / IDE MCP client, confirm `extract_json` with a `response_format` argument no longer returns "error decoding response body".

## Follow-up (out of scope)

A future PR could stop tracking the prebuilt binary entirely (gitignore + `git rm --cached` + a `beforeBuildCommand` so `tauri dev` still works). This PR keeps the binary tracked so the existing local dev workflow is unaffected.