### PR TITLE
Fix local image rendering in Markdown preview (#238)

### DIFF
--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -78,7 +78,7 @@ import {
   buildScrollAnchors,
   preservePreviewScroll,
 } from "./scroll-sync.ts";
-import { initPreview, renderPreview, getMermaid } from "./preview-render.ts";
+import { initPreview, renderPreview, getMermaid, setFilePathGetter } from "./preview-render.ts";
 import {
   initFileOps,
   saveFile,
@@ -245,6 +245,7 @@ const statusEl = document.getElementById("status")!;
 
 initScrollSync(editor, previewPane, cmScroller);
 initPreview(previewPane);
+setFilePathGetter(getCurrentFilePath);
 initClipboard(editor, previewPane, statusEl);
 
 // --- Orchestration functions ---

--- a/ui/src/preview-render.ts
+++ b/ui/src/preview-render.ts
@@ -9,8 +9,40 @@ import {
 } from "./scroll-sync.ts";
 import { escapeHtml, copySvgAsPng } from "./html-utils.ts";
 import { open as openMermaidViewer } from "./mermaid-viewer.ts";
+import { dirname } from "./path-utils.ts";
 
-const { invoke } = window.__TAURI__.core;
+const { invoke, convertFileSrc } = window.__TAURI__.core;
+
+// --- Local image path resolution ---
+
+let getFilePath: (() => string | null) | null = null;
+
+export function setFilePathGetter(getter: () => string | null) {
+  getFilePath = getter;
+}
+
+function resolveLocalImageSrc(href: string): string {
+  if (!href) return href;
+  if (href.startsWith("http://") || href.startsWith("https://") || href.startsWith("data:")) {
+    return href;
+  }
+  let absolute: string;
+  if (href.startsWith("/")) {
+    absolute = href;
+  } else {
+    const filePath = getFilePath?.();
+    if (!filePath) return href;
+    const base = dirname(filePath);
+    if (!base) return href;
+    try {
+      const resolved = new URL(href, `file://${base}/`);
+      absolute = decodeURIComponent(resolved.pathname);
+    } catch {
+      return href;
+    }
+  }
+  return convertFileSrc(absolute);
+}
 
 // --- Lazy-loaded modules ---
 
@@ -155,7 +187,7 @@ const figureExtension = {
       },
       renderer(token: { alt: string; src: string; caption: string }) {
         const altAttr = escapeHtml(token.alt);
-        const srcAttr = escapeHtml(token.src);
+        const srcAttr = escapeHtml(resolveLocalImageSrc(token.src));
         const captionHtml = escapeHtml(token.caption);
         return `<figure><img src="${srcAttr}" alt="${altAttr}" loading="lazy"><figcaption>${captionHtml}</figcaption></figure>\n`;
       },
@@ -312,6 +344,13 @@ marked.use({
     html({ text, _sourceLine }: any) {
       return _sourceLine ? text.replace(/^<(\w+)/, `<$1${slAttr(_sourceLine)}`) : text;
     },
+    image({ href, title, text }: any) {
+      const resolved = resolveLocalImageSrc(href ?? "");
+      const srcAttr = escapeHtml(resolved);
+      const altAttr = escapeHtml(text ?? "");
+      const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
+      return `<img src="${srcAttr}" alt="${altAttr}"${titleAttr}>`;
+    },
   },
 });
 
@@ -331,6 +370,8 @@ async function inlineSvgImages(container: HTMLElement) {
   const tasks = Array.from(imgs).map(async (img) => {
     const url = (img as HTMLImageElement).src;
     if (!url || (!url.startsWith("http://") && !url.startsWith("https://"))) return;
+    if (url.startsWith("https://asset.localhost/") || url.startsWith("http://asset.localhost/"))
+      return;
 
     try {
       let svgText: string | undefined;


### PR DESCRIPTION
## Summary

- Convert local image paths (`./image.png`, `../assets/x.png`, `/abs/path`) to the Tauri `asset://` protocol via `convertFileSrc()` so they render in the preview WebKit webview.
- Apply the conversion in both the default `marked` image renderer and the custom `figureExtension` renderer.
- Skip `https://asset.localhost/*` URLs in `inlineSvgImages()` so local SVGs are not sent to `fetch_svg`.

Fixes #238

## Test plan

- [x] Create a Markdown file and reference a local image with `![alt](./image.png)` — image renders in preview.
- [x] Verify `../assets/image.png` and absolute paths also render.
- [x] Verify remote `http(s)://` and `data:` images still render unchanged.
- [x] Verify a local `.svg` renders inline (or as an `<img>` without errors).
- [x] Verify the `figure` + caption syntax (`![alt](url)\n*caption*`) works for local images.