### PR TITLE
Enable Tauri asset protocol for local image rendering (#240)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1808,6 +1808,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4489,6 +4495,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "http-range",
  "jni",
  "libc",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/masanarihigashi/markupsidedown"
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-cli = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,7 +22,11 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": null,
+      "assetProtocol": {
+        "enable": true,
+        "scope": ["$HOME/**"]
+      }
     }
   },
   "plugins": {

--- a/ui/src/preview-render.ts
+++ b/ui/src/preview-render.ts
@@ -437,6 +437,11 @@ export async function renderPreview(source: string) {
   const sanitizedHtml = DOMPurify.sanitize(
     `<article class="preview-page" lang="en">${html}</article>`,
     {
+      // Allow Tauri's `asset:` scheme so local images survive sanitization
+      // (convertFileSrc returns asset://localhost/... on macOS/Linux). Mirrors
+      // DOMPurify's default ALLOWED_URI_REGEXP with `asset` added to the allowlist.
+      ALLOWED_URI_REGEXP:
+        /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|sms|cid|xmpp|matrix|asset):|[^a-z]|[a-z+.-]+(?:[^a-z+.\-:]|$))/i,
       ADD_TAGS: ["foreignObject"],
       ADD_ATTR: [
         "data-mermaid-source",


### PR DESCRIPTION
## Summary

Follow-up to #239. Local images still did not render in the preview on macOS because PR #239 assumed `convertFileSrc()` returns `https://asset.localhost/...`, when on macOS/Linux Tauri v2 actually returns the `asset://localhost/...` custom scheme. Three pieces were missing:

- **`src-tauri/Cargo.toml`** — enable the `protocol-asset` feature so the `asset://` URI scheme is registered in the WebKit webview.
- **`src-tauri/tauri.conf.json`** — add an `assetProtocol` scope (`$HOME/**`) so the webview is allowed to load files under the home directory. Matches the scope already used by the `fs:allow-write-text-file` capability.
- **`ui/src/preview-render.ts`** — add `asset` to DOMPurify's `ALLOWED_URI_REGEXP`; the default regexp does not allow the `asset:` scheme, so `<img src="asset://...">` was being stripped during sanitization.

This also fixes the sidebar image thumbnails (`sidebar.ts`), which use `convertFileSrc()` and were affected by the same missing `protocol-asset` registration.

## Root Cause

`convertFileSrc()` returns `asset://localhost/<encoded path>` on macOS/Linux and `http://asset.localhost/<encoded path>` on Windows (verified in `@tauri-apps/api`). Without the `protocol-asset` Cargo feature the scheme is never registered, and without `asset:` in DOMPurify's allowlist the `src` is removed before reaching the webview.

## Scope Limitation

Local images render only for paths under `$HOME` — an intentional security constraint of the `assetProtocol` scope. `csp` is `null`, so no CSP change is needed. Note: with Tauri's `require_literal_leading_dot` default on Unix, images inside dot-directories (e.g. `~/.config/...`) are not served.

## Verification

- [x] `cargo check` passes — `tauri-build` validates that the `protocol-asset` Cargo feature matches `assetProtocol.enable`, so the feature/config are in sync.
- [x] `vp check src/` passes (format + lint + types).
- [x] `ALLOWED_URI_REGEXP` unit-checked: allows `asset://`, preserves relative paths/links containing `/`, still blocks `javascript:` and `data:`.
- [x] Manual on macOS: confirm `![alt](./image.png)`, `../assets/x.png`, and absolute `$HOME` paths render in the preview, and that paths outside `$HOME` do not.

Fixes #240