### PR TITLE
perf(sidebar): eliminate N+1 list_directory IPC calls in tree refresh and filtering

### DIFF
--- a/src-tauri/src/bridge.rs
+++ b/src-tauri/src/bridge.rs
@@ -441,49 +441,16 @@ async fn list_files(
     }
 
     if query.recursive.unwrap_or(false) {
-        match list_recursive(&path).await {
+        match commands::list_recursive(&path).await {
             Ok(entries) => Json(serde_json::json!({ "entries": entries })),
             Err(e) => e.to_bridge_json(),
         }
     } else {
-        match commands::list_directory(path.clone()).await {
+        match commands::list_directory(path.clone(), None).await {
             Ok(entries) => Json(serde_json::json!({ "entries": entries })),
             Err(e) => e.to_bridge_json(),
         }
     }
-}
-
-/// Walk a directory tree recursively, filtering hidden files and git-ignored entries.
-/// Limits: max 20 levels deep, max 10 000 entries, skips `.git/`.
-async fn list_recursive(root: &str) -> Result<Vec<commands::FileEntry>, String> {
-    const MAX_DEPTH: usize = 20;
-    const MAX_ENTRIES: usize = 10_000;
-
-    let mut result = Vec::new();
-    // (path, depth)
-    let mut stack: Vec<(String, usize)> = vec![(root.to_string(), 0)];
-
-    while let Some((dir, depth)) = stack.pop() {
-        let entries = commands::list_directory(dir)
-            .await
-            .map_err(|e| e.to_string())?;
-        for entry in entries {
-            if entry.is_dir {
-                let name = entry.name.as_str();
-                if name == ".git" || name == "__pycache__" {
-                    continue;
-                }
-                if depth < MAX_DEPTH {
-                    stack.push((entry.path.clone(), depth + 1));
-                }
-            }
-            result.push(entry);
-            if result.len() >= MAX_ENTRIES {
-                return Ok(result);
-            }
-        }
-    }
-    Ok(result)
 }
 
 #[derive(Deserialize)]
@@ -522,7 +489,7 @@ async fn search_files(
     }
 
     // Fallback: recursive directory walk for non-git directories
-    match list_recursive(&search_path).await {
+    match commands::list_recursive(&search_path).await {
         Ok(entries) => {
             let query_lower = query.query.to_lowercase();
             let matches: Vec<&commands::FileEntry> = entries
@@ -579,6 +546,7 @@ async fn git_search_files(search_path: &str, query: &str) -> Option<Vec<commands
                     is_dir: false,
                     extension,
                     modified_at: None,
+                    fold_chain: None,
                 }
             })
             .collect();

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -56,6 +56,11 @@ pub struct FileEntry {
     pub is_dir: bool,
     pub extension: Option<String>,
     pub modified_at: Option<u64>,
+    /// Paths of successive lone child directories (single-child chains),
+    /// used by the sidebar to render folded directory names like "a/b/c".
+    /// Only populated when `list_directory` is called with `fold_info`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fold_chain: Option<Vec<String>>,
 }
 
 #[tauri::command]
@@ -105,10 +110,76 @@ pub async fn read_file_bytes(path: String) -> Result<Vec<u8>> {
 }
 
 #[tauri::command]
-pub async fn list_directory(path: String) -> Result<Vec<FileEntry>> {
+pub async fn list_directory(path: String, fold_info: Option<bool>) -> Result<Vec<FileEntry>> {
     let path = validate_path(&path)?;
+    let mut entries = read_dir_entries(&path).await?;
+    if fold_info.unwrap_or(false) {
+        for entry in entries.iter_mut().filter(|e| e.is_dir) {
+            entry.fold_chain = compute_fold_chain(&entry.path).await;
+        }
+    }
+    Ok(entries)
+}
+
+/// Walk down single-child directory chains starting at `start`.
+/// Returns the paths of successive lone child directories, or `None`
+/// when `start` contains anything other than exactly one directory.
+async fn compute_fold_chain(start: &str) -> Option<Vec<String>> {
+    const MAX_CHAIN: usize = 16; // guard against symlink loops
+    let mut chain = Vec::new();
+    let mut current = std::path::PathBuf::from(start);
+    while chain.len() < MAX_CHAIN {
+        let Ok(entries) = read_dir_entries(&current).await else {
+            break;
+        };
+        if entries.len() != 1 || !entries[0].is_dir {
+            break;
+        }
+        chain.push(entries[0].path.clone());
+        current = std::path::PathBuf::from(&entries[0].path);
+    }
+    (!chain.is_empty()).then_some(chain)
+}
+
+/// Walk a directory tree recursively, applying the same hidden-entry
+/// filtering as `list_directory`. Limits: max 20 levels deep,
+/// max 10 000 entries, skips `.git/` and `__pycache__/`.
+pub async fn list_recursive(root: &str) -> Result<Vec<FileEntry>> {
+    const MAX_DEPTH: usize = 20;
+    const MAX_ENTRIES: usize = 10_000;
+
+    let mut result = Vec::new();
+    let mut stack: Vec<(std::path::PathBuf, usize)> = vec![(validate_path(root)?, 0)];
+
+    while let Some((dir, depth)) = stack.pop() {
+        let entries = read_dir_entries(&dir).await?;
+        for entry in entries {
+            if entry.is_dir {
+                let name = entry.name.as_str();
+                if name == ".git" || name == "__pycache__" {
+                    continue;
+                }
+                if depth < MAX_DEPTH {
+                    stack.push((std::path::PathBuf::from(&entry.path), depth + 1));
+                }
+            }
+            result.push(entry);
+            if result.len() >= MAX_ENTRIES {
+                return Ok(result);
+            }
+        }
+    }
+    Ok(result)
+}
+
+#[tauri::command]
+pub async fn list_directory_recursive(path: String) -> Result<Vec<FileEntry>> {
+    list_recursive(&path).await
+}
+
+async fn read_dir_entries(path: &std::path::Path) -> Result<Vec<FileEntry>> {
     let mut entries = Vec::new();
-    let mut read_dir = tokio::fs::read_dir(&path)
+    let mut read_dir = tokio::fs::read_dir(path)
         .await
         .map_err(|e| AppError::Io(format!("Failed to read directory: {e}")))?;
 
@@ -142,6 +213,7 @@ pub async fn list_directory(path: String) -> Result<Vec<FileEntry>> {
             is_dir: file_type.is_dir(),
             extension,
             modified_at,
+            fold_chain: None,
         });
     }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -154,6 +154,7 @@ fn main() {
             commands::copy_to_clipboard,
             commands::read_file_bytes,
             commands::list_directory,
+            commands::list_directory_recursive,
             commands::create_file,
             commands::create_directory,
             commands::rename_entry,

--- a/ui/src/sidebar.ts
+++ b/ui/src/sidebar.ts
@@ -78,6 +78,7 @@ interface DirEntry {
   is_dir: boolean;
   extension: string | null;
   modified_at: number | null;
+  fold_chain?: string[];
 }
 
 interface GitStatus {
@@ -103,6 +104,11 @@ let gitStatusMap: Map<string, GitStatus> = new Map();
 let refreshGeneration = 0; // guards against concurrent refreshTree() races
 let filterQuery = "";
 let filterScope: string | null = null; // null = global, path = scoped to folder
+// Recursive listing cache (parent dir -> entries) used while filtering, so
+// each keystroke renders from one recursive IPC call instead of walking the
+// tree with per-directory list_directory calls.
+let filterCache: Map<string, DirEntry[]> | null = null;
+let reuseFilterCache = false;
 let dragSourcePaths = new Set<string>();
 let clipboardPaths = new Set<string>();
 let clipboardMode: "cut" | "copy" | null = null;
@@ -472,6 +478,7 @@ function render() {
     if (filterTimeout) clearTimeout(filterTimeout);
     filterTimeout = setTimeout(() => {
       filterQuery = searchInput.value.trim().toLowerCase();
+      reuseFilterCache = true;
       refreshTree();
     }, 150);
   });
@@ -804,6 +811,23 @@ export async function refreshTree() {
 
   const gen = ++refreshGeneration;
 
+  // While filtering, render from one recursive listing instead of walking
+  // the tree with per-directory IPC calls. The cache is reused only between
+  // filter keystrokes (reuseFilterCache); any other trigger rebuilds it.
+  if (filterQuery || tagFilter) {
+    if (!filterCache || !reuseFilterCache) {
+      try {
+        filterCache = await buildFilterCache(rootPath);
+      } catch {
+        filterCache = null; // fall back to per-directory listing
+      }
+      if (gen !== refreshGeneration) return;
+    }
+  } else {
+    filterCache = null;
+  }
+  reuseFilterCache = false;
+
   // Build a completely new tree element off-DOM
   const newTree = document.createElement("div");
   newTree.className = "sidebar-tree";
@@ -848,15 +872,27 @@ export async function refreshTree() {
   updateTagChipBar();
 }
 
+async function buildFilterCache(root: string): Promise<Map<string, DirEntry[]>> {
+  const entries = await invoke<DirEntry[]>("list_directory_recursive", { path: root });
+  const byDir = new Map<string, DirEntry[]>();
+  for (const e of entries) {
+    const parent = dirname(e.path);
+    const siblings = byDir.get(parent);
+    if (siblings) siblings.push(e);
+    else byDir.set(parent, [e]);
+  }
+  return byDir;
+}
+
 async function renderDirectory(
   dirPath: string,
   container: HTMLElement,
   depth: number,
   gen: number,
 ): Promise<boolean> {
-  const entries = await invoke<DirEntry[]>("list_directory", {
-    path: dirPath,
-  });
+  const entries = filterCache
+    ? (filterCache.get(dirPath) ?? [])
+    : await invoke<DirEntry[]>("list_directory", { path: dirPath, foldInfo: true });
   if (gen !== refreshGeneration) return false;
 
   // Sort entries by user preference (directories always first)
@@ -907,30 +943,21 @@ async function renderDirectory(
     if (!showDotfiles && entry.name.startsWith(".")) continue;
 
     if (entry.is_dir) {
-      // Auto-fold: detect chain of single-child directories
+      // Auto-fold: collapse chains of single-child directories.
+      // The chain is computed Rust-side (fold_chain) — no extra IPC calls.
       let foldedEntry = entry;
       let displayName = entry.name;
 
-      if (!isFiltering && !isTagFiltering) {
-        let folding = true;
-        while (folding) {
-          const subEntries = await invoke<DirEntry[]>("list_directory", {
-            path: foldedEntry.path,
-          });
-          if (gen !== refreshGeneration) return false;
-          const subDirs = subEntries.filter((e) => e.is_dir);
-          const subFiles = subEntries.filter((e) => !e.is_dir);
-          if (subDirs.length === 1 && subFiles.length === 0) {
-            // Migrate expanded state from intermediate path to final path
-            if (expandedDirs.has(foldedEntry.path) && !expandedDirs.has(subDirs[0].path)) {
-              expandedDirs.add(subDirs[0].path);
-              expandedDirs.delete(foldedEntry.path);
-            }
-            displayName += "/" + subDirs[0].name;
-            foldedEntry = subDirs[0];
-          } else {
-            folding = false;
+      if (!isFiltering && !isTagFiltering && entry.fold_chain) {
+        for (const childPath of entry.fold_chain) {
+          // Migrate expanded state from intermediate path to final path
+          if (expandedDirs.has(foldedEntry.path) && !expandedDirs.has(childPath)) {
+            expandedDirs.add(childPath);
+            expandedDirs.delete(foldedEntry.path);
           }
+          const childName = basename(childPath);
+          displayName += "/" + childName;
+          foldedEntry = { ...foldedEntry, path: childPath, name: childName };
         }
       }
 


### PR DESCRIPTION
Closes #250

## Changes

**Auto-fold single-child detection (was: 1+ extra IPC call per directory entry per refresh)**
- `list_directory` now accepts an opt-in `fold_info` flag; when set, Rust walks single-child directory chains locally and returns them as a `fold_chain` field on each directory entry
- The sidebar renders folded names (`a/b/c`) from `fold_chain` with zero extra IPC round-trips, including for collapsed directories

**Filter typing (was: full per-directory tree walk on every keystroke)**
- New `list_directory_recursive` command (moved `list_recursive` from `bridge.rs` into `commands/files.rs`, now shared by the bridge and the command)
- While a name or tag filter is active, the sidebar renders from a single recursive listing grouped by parent directory, cached between filter keystrokes; any other refresh trigger (FS watcher, file ops, focus) rebuilds the cache so results stay fresh
- On cache build failure it falls back to the previous per-directory path

## Notes
- `list_recursive` now returns `AppError` instead of `String`, so bridge error categorization is preserved
- Filtering now skips `.git/` contents (recursive listing already skipped them in the bridge) — previously a filter with dotfiles visible could surface matches inside `.git`

## Verification
- `cargo check` passes
- `vp check src/` and `tsc --noEmit` pass