### PR TITLE
perf(ipc): stop transferring file bytes as JSON number arrays

### DIFF
--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -97,11 +97,31 @@ pub async fn copy_to_clipboard(text: String) -> Result<()> {
 }
 
 #[tauri::command]
-pub async fn read_file_bytes(path: String) -> Result<Vec<u8>> {
+pub async fn read_file_bytes(path: String) -> Result<tauri::ipc::Response> {
     let path = validate_path(&path)?;
-    tokio::fs::read(&path)
+    let data = tokio::fs::read(&path)
         .await
-        .map_err(|e| AppError::Io(format!("Failed to read file: {e}")))
+        .map_err(|e| AppError::Io(format!("Failed to read file: {e}")))?;
+    // Raw IPC response — the frontend receives an ArrayBuffer instead of a
+    // JSON number array.
+    Ok(tauri::ipc::Response::new(data))
+}
+
+/// Extract the percent-encoded `path` header and raw binary body from a
+/// raw-IPC request (used by commands that receive file bytes from JS).
+fn raw_request_parts<'a>(request: &'a tauri::ipc::Request<'_>) -> Result<(String, &'a [u8])> {
+    let tauri::ipc::InvokeBody::Raw(data) = request.body() else {
+        return Err(AppError::Validation("Expected raw binary request body".into()));
+    };
+    let encoded = request
+        .headers()
+        .get("path")
+        .and_then(|v| v.to_str().ok())
+        .ok_or_else(|| AppError::Validation("Missing path header".into()))?;
+    let path = urlencoding::decode(encoded)
+        .map_err(|e| AppError::Validation(format!("Invalid path header: {e}")))?
+        .into_owned();
+    Ok((path, data.as_slice()))
 }
 
 #[tauri::command]
@@ -200,7 +220,8 @@ pub async fn rename_entry(from: String, to: String) -> Result<()> {
 }
 
 #[tauri::command]
-pub async fn write_file_bytes(path: String, data: Vec<u8>) -> Result<()> {
+pub async fn write_file_bytes(request: tauri::ipc::Request<'_>) -> Result<()> {
+    let (path, data) = raw_request_parts(&request)?;
     let dest = validate_path(&path)?;
     if dest.exists() {
         return Err(AppError::Io(format!(
@@ -210,20 +231,21 @@ pub async fn write_file_bytes(path: String, data: Vec<u8>) -> Result<()> {
                 .unwrap_or_default()
         )));
     }
-    tokio::fs::write(&dest, &data)
+    tokio::fs::write(&dest, data)
         .await
         .map_err(|e| AppError::Io(format!("Failed to write file: {e}")))
 }
 
 #[tauri::command]
-pub async fn save_image(path: String, data: Vec<u8>) -> Result<()> {
+pub async fn save_image(request: tauri::ipc::Request<'_>) -> Result<()> {
+    let (path, data) = raw_request_parts(&request)?;
     let dest = validate_path(&path)?;
     if let Some(parent) = dest.parent() {
         tokio::fs::create_dir_all(parent)
             .await
             .map_err(|e| AppError::Io(format!("Failed to create directory: {e}")))?;
     }
-    tokio::fs::write(&dest, &data)
+    tokio::fs::write(&dest, data)
         .await
         .map_err(|e| AppError::Io(format!("Failed to save image: {e}")))
 }

--- a/ui/src/batch-import.ts
+++ b/ui/src/batch-import.ts
@@ -51,9 +51,8 @@ export async function submitBatch(
 ): Promise<{ batchId: string; total: number }> {
   const files: BatchFile[] = await Promise.all(
     filePaths.map(async (fp) => {
-      const bytes = await invoke<number[]>("read_file_bytes", { path: fp });
-      const b64 = arrayBufferToBase64(new Uint8Array(bytes).buffer);
-      return { name: basename(fp), content: b64 };
+      const bytes = await invoke<ArrayBuffer>("read_file_bytes", { path: fp });
+      return { name: basename(fp), content: arrayBufferToBase64(bytes) };
     }),
   );
 

--- a/ui/src/file-ops.ts
+++ b/ui/src/file-ops.ts
@@ -341,8 +341,9 @@ export function initDragDrop(appEl: HTMLElement) {
       const targetPath = `${root}/${file.name}`;
       try {
         const buffer = await file.arrayBuffer();
-        const data = Array.from(new Uint8Array(buffer));
-        await invoke("write_file_bytes", { path: targetPath, data });
+        await invoke("write_file_bytes", new Uint8Array(buffer), {
+          headers: { path: encodeURIComponent(targetPath) },
+        });
         if (MD_EXTENSIONS.has(ext)) {
           const content = await invoke<string>("read_text_file", { path: targetPath });
           loadContentAsTab(content, targetPath);

--- a/ui/src/global.d.ts
+++ b/ui/src/global.d.ts
@@ -1,6 +1,10 @@
 // Tauri global API (withGlobalTauri: true)
 interface TauriCore {
-  invoke<T = unknown>(cmd: string, args?: Record<string, unknown>): Promise<T>;
+  invoke<T = unknown>(
+    cmd: string,
+    args?: Record<string, unknown> | ArrayBuffer | Uint8Array,
+    options?: { headers?: Record<string, string> },
+  ): Promise<T>;
   convertFileSrc(filePath: string, protocol?: string): string;
 }
 

--- a/ui/src/image-paste.ts
+++ b/ui/src/image-paste.ts
@@ -43,7 +43,7 @@ async function saveAndInsert(data: Uint8Array, filename: string, pos: number) {
   const destPath = `${assetsDir}/${filename}`;
 
   try {
-    await invoke("save_image", { path: destPath, data: Array.from(data) });
+    await invoke("save_image", data, { headers: { path: encodeURIComponent(destPath) } });
   } catch (e) {
     deps.statusEl.textContent = `Failed to save image: ${e}`;
     return;

--- a/ui/src/sidebar.ts
+++ b/ui/src/sidebar.ts
@@ -1271,8 +1271,9 @@ async function handleExternalFileDrop(files: FileList, targetDir: string) {
 
     try {
       const buffer = await file.arrayBuffer();
-      const data = Array.from(new Uint8Array(buffer));
-      await invoke("write_file_bytes", { path: targetPath, data });
+      await invoke("write_file_bytes", new Uint8Array(buffer), {
+        headers: { path: encodeURIComponent(targetPath) },
+      });
       copiedCount++;
 
       if (MD_EXTENSIONS.has(ext)) {


### PR DESCRIPTION
Closes #251

## Changes

- `write_file_bytes` and `save_image` now receive Tauri v2 **raw binary IPC** bodies (`tauri::ipc::Request` + `InvokeBody::Raw`). The destination path travels as a percent-encoded `path` header (headers must be ASCII; paths may contain non-ASCII filenames) and is decoded with the existing `urlencoding` dependency before the usual `validate_path` check.
- `read_file_bytes` returns `tauri::ipc::Response` (raw bytes → `ArrayBuffer` in JS) instead of `Vec<u8>` serialized as a JSON number array; batch import base64-encodes from the ArrayBuffer directly.
- Updated call sites: sidebar external drop, editor-area drop (`file-ops.ts`), image paste, batch import. `global.d.ts` invoke signature extended for binary payloads + headers.

Dropping a 50MB PDF previously inflated the IPC payload ~4x and allocated a huge JS number array; both directions now stay binary end-to-end.

## Verification
- `cargo check` passes
- `vp check src/` and `tsc --noEmit` pass