### PR TITLE
perf(watcher): replace 3s full-file read polls with stat-based mtime checks

### DIFF
--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -96,6 +96,32 @@ pub async fn copy_to_clipboard(text: String) -> Result<()> {
     .await?
 }
 
+#[derive(Serialize)]
+pub struct FileStat {
+    pub mtime_ms: u64,
+    pub size: u64,
+}
+
+/// Lightweight metadata check used by the frontend poll fallbacks, so the
+/// active file / project root is only re-read when something changed.
+#[tauri::command]
+pub async fn stat_file(path: String) -> Result<FileStat> {
+    let path = validate_read_path(&path)?;
+    let meta = tokio::fs::metadata(&path)
+        .await
+        .map_err(|e| AppError::Io(format!("Failed to stat file: {e}")))?;
+    let mtime_ms = meta
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    Ok(FileStat {
+        mtime_ms,
+        size: meta.len(),
+    })
+}
+
 #[tauri::command]
 pub async fn read_file_bytes(path: String) -> Result<Vec<u8>> {
     let path = validate_path(&path)?;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -153,6 +153,7 @@ fn main() {
             commands::write_text_file,
             commands::copy_to_clipboard,
             commands::read_file_bytes,
+            commands::stat_file,
             commands::list_directory,
             commands::create_file,
             commands::create_directory,

--- a/ui/src/file-watcher.ts
+++ b/ui/src/file-watcher.ts
@@ -17,12 +17,17 @@ const reloadTimers = new Map<string, ReturnType<typeof setTimeout>>();
 const RELOAD_DEBOUNCE_MS = 800;
 
 // Poll fallback: macOS FSEvents can miss events for individual file watches,
-// especially with atomic writes (write temp → rename). Periodic content polling
+// especially with atomic writes (write temp → rename). Periodic metadata polling
 // catches changes the watcher misses.
 let pollTimer: ReturnType<typeof setInterval> | null = null;
 const POLL_INTERVAL_MS = 3000;
 let lastPolledPath: string | null = null;
-let lastPolledContent: string | null = null;
+let lastPolledStat: string | null = null;
+
+interface FileStat {
+  mtime_ms: number;
+  size: number;
+}
 
 // Dependencies injected via init
 let deps: {
@@ -110,10 +115,10 @@ function onFileChanged(event: WatchEvent) {
   }
 }
 
-// Poll active tab's file by reading content and comparing with savedContent.
-// Uses read_text_file (Tauri command) which has proper fs permissions,
-// unlike stat() which may lack fs:allow-stat permission.
-// Caches last-read disk content to avoid triggering reload when nothing changed.
+// Poll active tab's file via a cheap (mtime, size) metadata check; the
+// content is only read and compared when the metadata changed.
+// Uses stat_file (Tauri command) which has proper fs permissions,
+// unlike plugin-fs stat() which may lack fs:allow-stat permission.
 function startPolling() {
   if (pollTimer) return;
   pollTimer = setInterval(async () => {
@@ -124,11 +129,13 @@ function startPolling() {
     if (isRecentlySuppressed(path)) return;
 
     try {
-      const diskContent = await invoke<string>("read_text_file", { path });
-      // Skip if disk content hasn't changed since last poll
-      if (path === lastPolledPath && diskContent === lastPolledContent) return;
+      const stat = await invoke<FileStat>("stat_file", { path });
+      const statKey = `${stat.mtime_ms}:${stat.size}`;
+      // Skip the full read when the file metadata hasn't changed
+      if (path === lastPolledPath && statKey === lastPolledStat) return;
       lastPolledPath = path;
-      lastPolledContent = diskContent;
+      lastPolledStat = statKey;
+      const diskContent = await invoke<string>("read_text_file", { path });
       if (activeTab.savedContent !== null && diskContent !== activeTab.savedContent) {
         await reloadPath(path);
       }

--- a/ui/src/sidebar.ts
+++ b/ui/src/sidebar.ts
@@ -674,9 +674,16 @@ export async function openFolderByPath(path: string) {
   onFolderChange?.(rootPath);
 }
 
-// Snapshot of the last-known top-level directory listing.
-// Used by the poll fallback to detect changes cheaply.
+// Last-known (mtime, size) of the root directory.
+// Used by the poll fallback to detect changes cheaply — a directory's mtime
+// changes when direct children are created, deleted, or renamed, which is
+// the same coverage as the previous top-level listing snapshot.
 let lastDirSnapshot = "";
+
+async function statSnapshot(path: string): Promise<string> {
+  const stat = await invoke<{ mtime_ms: number; size: number }>("stat_file", { path });
+  return `${stat.mtime_ms}:${stat.size}`;
+}
 
 async function startDirWatcher() {
   stopDirWatcher();
@@ -700,16 +707,13 @@ async function startDirWatcher() {
   }
 
   // Poll fallback: macOS FSEvents can miss new-file-creation events from
-  // external processes. Compare a lightweight snapshot of the root directory
-  // to detect changes the watcher missed (mirrors file-watcher.ts design).
+  // external processes. Compare the root directory's (mtime, size) to detect
+  // changes the watcher missed (mirrors file-watcher.ts design).
   const watchRoot = rootPath;
   dirPollTimer = setInterval(async () => {
     if (!rootPath || rootPath !== watchRoot || document.hidden) return;
     try {
-      const entries = await invoke<DirEntry[]>("list_directory", {
-        path: rootPath,
-      });
-      const snapshot = entries.map((e) => `${e.name}:${e.is_dir}`).join("|");
+      const snapshot = await statSnapshot(rootPath);
       if (lastDirSnapshot && snapshot !== lastDirSnapshot) {
         refreshTree();
         onExternalChange?.();
@@ -722,10 +726,7 @@ async function startDirWatcher() {
 
   // Capture initial snapshot
   try {
-    const entries = await invoke<DirEntry[]>("list_directory", {
-      path: rootPath,
-    });
-    lastDirSnapshot = entries.map((e) => `${e.name}:${e.is_dir}`).join("|");
+    lastDirSnapshot = await statSnapshot(rootPath);
   } catch {
     // ignore
   }


### PR DESCRIPTION
Closes #252

## Changes

- New `stat_file` Tauri command returning `(mtime_ms, size)` via `tokio::fs::metadata`. Being a Rust-side command it goes through the existing path validation, avoiding the plugin-fs `stat()` permission concern noted in the original comment.
- **file-watcher poll fallback**: the 3-second poll now compares `(mtime, size)` first and only reads + compares the file content when the metadata changed. Previously every cycle did a full disk read + UTF-8 decode + IPC string transfer of the active file.
- **sidebar directory poll**: compares the root directory's `(mtime, size)` instead of listing it every cycle. A directory's mtime changes when direct children are created/deleted/renamed — the same coverage as the previous top-level name snapshot.

## Verification
- `cargo check` passes
- `vp check src/` and `tsc --noEmit` pass