### PR TITLE
perf(bridge): avoid cloning full editor state per request

### DIFF
--- a/src-tauri/src/bridge.rs
+++ b/src-tauri/src/bridge.rs
@@ -34,20 +34,6 @@ impl BridgeState {
         let _ = self.app.emit(event, payload);
     }
 
-    /// Get state for a specific window, or fall back to focused.
-    fn get_state_for(&self, window: Option<&str>) -> Option<commands::EditorStateInner> {
-        if let Some(label) = window {
-            if let Some(state) = self.editor.get_window_state(label) {
-                return Some(state);
-            }
-        }
-        self.editor.get_focused_state()
-    }
-
-    /// Get root path for a specific window, or fall back to focused.
-    fn get_root_for(&self, window: Option<&str>) -> Option<String> {
-        self.get_state_for(window).and_then(|s| s.root_path)
-    }
 }
 
 fn port_file_path() -> PathBuf {
@@ -197,8 +183,8 @@ async fn get_content(
     Query(wq): Query<WindowQuery>,
 ) -> Json<serde_json::Value> {
     let content = state
-        .get_state_for(wq.window.as_deref())
-        .map(|s| s.content)
+        .editor
+        .with_state(wq.window.as_deref(), |s| s.content.clone())
         .unwrap_or_default();
     Json(serde_json::json!({ "content": content }))
 }
@@ -246,7 +232,7 @@ async fn insert_text(
     StatusCode::OK
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Default)]
 struct EditorStateResponse {
     file_path: Option<String>,
     worker_url: Option<String>,
@@ -259,14 +245,17 @@ async fn get_state(
     State(state): State<Arc<BridgeState>>,
     Query(wq): Query<WindowQuery>,
 ) -> Json<EditorStateResponse> {
-    let s = state.get_state_for(wq.window.as_deref()).unwrap_or_default();
-    Json(EditorStateResponse {
-        file_path: s.file_path,
-        worker_url: s.worker_url,
-        cursor_pos: s.cursor_pos,
-        cursor_line: s.cursor_line,
-        cursor_column: s.cursor_column,
-    })
+    let resp = state
+        .editor
+        .with_state(wq.window.as_deref(), |s| EditorStateResponse {
+            file_path: s.file_path.clone(),
+            worker_url: s.worker_url.clone(),
+            cursor_pos: s.cursor_pos,
+            cursor_line: s.cursor_line,
+            cursor_column: s.cursor_column,
+        })
+        .unwrap_or_default();
+    Json(resp)
 }
 
 #[derive(Deserialize)]
@@ -312,8 +301,10 @@ async fn get_lint(
     State(state): State<Arc<BridgeState>>,
     Query(wq): Query<WindowQuery>,
 ) -> Json<serde_json::Value> {
-    let s = state.get_state_for(wq.window.as_deref());
-    match s.and_then(|s| s.lint_diagnostics) {
+    let s = state
+        .editor
+        .with_state(wq.window.as_deref(), |s| s.lint_diagnostics.clone());
+    match s.flatten() {
         Some(json_str) => {
             if let Ok(val) = serde_json::from_str::<serde_json::Value>(&json_str) {
                 Json(serde_json::json!({ "diagnostics": val }))
@@ -329,8 +320,10 @@ async fn get_structure(
     State(state): State<Arc<BridgeState>>,
     Query(wq): Query<WindowQuery>,
 ) -> Json<serde_json::Value> {
-    let s = state.get_state_for(wq.window.as_deref());
-    match s.and_then(|s| s.document_structure) {
+    let s = state
+        .editor
+        .with_state(wq.window.as_deref(), |s| s.document_structure.clone());
+    match s.flatten() {
         Some(json_str) => {
             if let Ok(val) = serde_json::from_str::<serde_json::Value>(&json_str) {
                 Json(val)
@@ -349,8 +342,8 @@ async fn get_tabs(
     Query(wq): Query<WindowQuery>,
 ) -> Json<serde_json::Value> {
     let tabs: Vec<serde_json::Value> = state
-        .get_state_for(wq.window.as_deref())
-        .map(|s| {
+        .editor
+        .with_state(wq.window.as_deref(), |s| {
             s.tabs
                 .iter()
                 .map(|t| {
@@ -371,7 +364,11 @@ async fn get_root(
     State(state): State<Arc<BridgeState>>,
     Query(wq): Query<WindowQuery>,
 ) -> Json<serde_json::Value> {
-    Json(serde_json::json!({ "root_path": state.get_root_for(wq.window.as_deref()) }))
+    let root_path = state
+        .editor
+        .with_state(wq.window.as_deref(), |s| s.root_path.clone())
+        .flatten();
+    Json(serde_json::json!({ "root_path": root_path }))
 }
 
 async fn get_dirty_files(
@@ -379,8 +376,8 @@ async fn get_dirty_files(
     Query(wq): Query<WindowQuery>,
 ) -> Json<serde_json::Value> {
     let dirty: Vec<serde_json::Value> = state
-        .get_state_for(wq.window.as_deref())
-        .map(|s| {
+        .editor
+        .with_state(wq.window.as_deref(), |s| {
             s.tabs
                 .iter()
                 .filter(|t| t.is_dirty)

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -56,17 +56,29 @@ impl Default for EditorStates {
 }
 
 impl EditorStates {
-    /// Get a clone of the focused window's state, or the first available window's state.
-    pub fn get_focused_state(&self) -> Option<EditorStateInner> {
+    /// Run `f` against the state for `label` (when given and present),
+    /// falling back to the focused window, then any window. Lets callers
+    /// extract just the fields they need without cloning the entire
+    /// EditorStateInner (content + structure/lint JSON can be several MB).
+    pub fn with_state<T>(
+        &self,
+        label: Option<&str>,
+        f: impl FnOnce(&EditorStateInner) -> T,
+    ) -> Option<T> {
         let map = self.map.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(label) = label {
+            if let Some(state) = map.get(label) {
+                return Some(f(state));
+            }
+        }
         let focused = self.focused.lock().unwrap_or_else(|e| e.into_inner());
         if let Some(label) = focused.as_ref() {
             if let Some(state) = map.get(label) {
-                return Some(state.clone());
+                return Some(f(state));
             }
         }
-        // Fallback: return first available window's state
-        map.values().next().cloned()
+        // Fallback: first available window's state
+        map.values().next().map(f)
     }
 
     /// Remove a window's state entry.
@@ -90,26 +102,8 @@ impl EditorStates {
             .clone()
     }
 
-    /// Get a single field from the focused window's state without cloning the entire struct.
-    fn get_focused_field<T>(&self, f: impl FnOnce(&EditorStateInner) -> T) -> Option<T> {
-        let map = self.map.lock().unwrap_or_else(|e| e.into_inner());
-        let focused = self.focused.lock().unwrap_or_else(|e| e.into_inner());
-        if let Some(label) = focused.as_ref() {
-            if let Some(state) = map.get(label) {
-                return Some(f(state));
-            }
-        }
-        map.values().next().map(f)
-    }
-
     pub fn get_focused_root_path(&self) -> Option<String> {
-        self.get_focused_field(|s| s.root_path.clone()).flatten()
-    }
-
-    /// Get the state for a specific window by label.
-    pub fn get_window_state(&self, label: &str) -> Option<EditorStateInner> {
-        let map = self.map.lock().unwrap_or_else(|e| e.into_inner());
-        map.get(label).cloned()
+        self.with_state(None, |s| s.root_path.clone()).flatten()
     }
 
     /// Get all window labels and their root paths.


### PR DESCRIPTION
Closes #253

## Changes

- Replace `EditorStates::get_focused_state` / `get_window_state` (each cloned the entire `EditorStateInner` — `content` plus `document_structure`/`lint_diagnostics` JSON strings — while holding the mutex) with a single `with_state(label, closure)` accessor that borrows the state, generalizing the existing `get_focused_field` pattern to window-targeted lookups.
- Bridge endpoints now clone only what they return:
  - `/editor/root`, `/editor/state`, `/editor/tabs`, `/editor/dirty-files` — small fields only, no content copy at all
  - `/editor/content`, `/editor/structure`, `/editor/lint` — clone just the one string they serve
- `get_state_for` / `get_root_for` helpers in `bridge.rs` are gone; fallback order (explicit window → focused → first available) is unchanged.

For a large open document this removes several MB of copying per MCP tool call on the metadata endpoints.

## Verification
- `cargo check` passes (only the pre-existing `tool_router` warning in mcp-server-rs remains)