### PR TITLE
perf(git): reduce git process spawns triggered by the autosave chain

### DIFF
--- a/src-tauri/src/bridge.rs
+++ b/src-tauri/src/bridge.rs
@@ -649,7 +649,7 @@ async fn git_status(State(state): State<Arc<BridgeState>>) -> Json<serde_json::V
         return not_found_json("No project root available");
     };
 
-    match commands::git_status(repo_path).await {
+    match commands::git_status(repo_path, None).await {
         Ok(status) => Json(serde_json::json!(status)),
         Err(e) => e.to_bridge_json(),
     }

--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -111,14 +111,23 @@ pub struct GitStatus {
 }
 
 #[tauri::command]
-pub async fn git_status(repo_path: String) -> Result<GitStatus> {
+pub async fn git_status(repo_path: String, include_stats: Option<bool>) -> Result<GitStatus> {
+    let include_stats = include_stats.unwrap_or(true);
     spawn_blocking(move || {
-        // Hold lock for all three commands to avoid racing with multi-step
+        // Hold lock for all commands to avoid racing with multi-step
         // operations like git_revert (stash -> revert -> pop).
         let _guard = GIT_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let status_result = run_git_unlocked(&repo_path, &["status", "-b", "--porcelain=v1"]).ok();
-        let unstaged_raw = run_git_unlocked(&repo_path, &["diff", "--numstat"]).ok();
-        let staged_raw = run_git_unlocked(&repo_path, &["diff", "--cached", "--numstat"]).ok();
+        // The per-file line counts are only shown in the git panel, so
+        // callers can skip the two diff processes when it is hidden.
+        let (unstaged_raw, staged_raw) = if include_stats {
+            (
+                run_git_unlocked(&repo_path, &["diff", "--numstat"]).ok(),
+                run_git_unlocked(&repo_path, &["diff", "--cached", "--numstat"]).ok(),
+            )
+        } else {
+            (None, None)
+        };
 
         let output = match status_result {
             Some(o) => o,

--- a/ui/src/file-ops.ts
+++ b/ui/src/file-ops.ts
@@ -48,6 +48,7 @@ let statusEl: HTMLElement;
 let getCurrentFilePath: () => string | null;
 let loadContentAsTab: (content: string, filePath?: string, tabName?: string) => void;
 let refreshGitAndSync: () => void;
+let refreshGitAfterAutoSave: (path: string) => void;
 
 export function initFileOps(deps: {
   editor: EditorView;
@@ -55,12 +56,14 @@ export function initFileOps(deps: {
   getCurrentFilePath: () => string | null;
   loadContentAsTab: (content: string, filePath?: string, tabName?: string) => void;
   refreshGitAndSync: () => void;
+  refreshGitAfterAutoSave?: (path: string) => void;
 }) {
   editor = deps.editor;
   statusEl = deps.statusEl;
   getCurrentFilePath = deps.getCurrentFilePath;
   loadContentAsTab = deps.loadContentAsTab;
   refreshGitAndSync = deps.refreshGitAndSync;
+  refreshGitAfterAutoSave = deps.refreshGitAfterAutoSave ?? deps.refreshGitAndSync;
 }
 
 // --- Title extraction ---
@@ -149,7 +152,7 @@ export async function autoSave() {
     suppressNext(currentFilePath);
     await writeTextFile(currentFilePath, content);
     markTabSaved(tab.id);
-    if (getRootPath()) refreshGitAndSync();
+    if (getRootPath()) refreshGitAfterAutoSave(currentFilePath);
   } catch (e) {
     statusEl.textContent = `Auto-save failed: ${e}`;
   }

--- a/ui/src/git-panel.ts
+++ b/ui/src/git-panel.ts
@@ -35,6 +35,7 @@ let logEntries: GitLogEntry[] = [];
 let onFileClick: ((path: string) => void) | null = null;
 let onRefreshCb: (() => void) | null = null;
 let onFilesChangedCb: (() => void) | null = null;
+let isVisibleCb: (() => boolean) | null = null;
 let commitMessage = generateDefaultMessage();
 
 // Track which file's diff is currently expanded (by path or commit hash)
@@ -54,12 +55,19 @@ export function initGitPanel(
     onOpen,
     onRefresh,
     onFilesChanged,
-  }: { onOpen: (path: string) => void; onRefresh?: () => void; onFilesChanged?: () => void },
+    isVisible,
+  }: {
+    onOpen: (path: string) => void;
+    onRefresh?: () => void;
+    onFilesChanged?: () => void;
+    isVisible?: () => boolean;
+  },
 ) {
   panelEl = el;
   onFileClick = onOpen;
   onRefreshCb = onRefresh ?? null;
   onFilesChangedCb = onFilesChanged ?? null;
+  isVisibleCb = isVisible ?? null;
   render();
 }
 
@@ -76,9 +84,14 @@ export function setRepoPath(path: string | null, skipRefresh = false) {
 
 export async function refresh() {
   if (!repoPath) return;
+  // Per-file line counts (two extra git diff processes) and the commit log
+  // are only rendered inside the panel — skip them while it is hidden.
+  const visible = isVisibleCb?.() ?? true;
   const [statusResult, logResult] = await Promise.allSettled([
-    invoke<GitData>("git_status", { repoPath }),
-    invoke<GitLogEntry[]>("git_log", { repoPath, limit: 10 }),
+    invoke<GitData>("git_status", { repoPath, includeStats: visible }),
+    visible
+      ? invoke<GitLogEntry[]>("git_log", { repoPath, limit: 10 })
+      : Promise.resolve(logEntries),
   ]);
   gitData = statusResult.status === "fulfilled" ? statusResult.value : null;
   logEntries = logResult.status === "fulfilled" ? logResult.value : [];

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -28,6 +28,7 @@ import {
   updateGitChangeCount,
   refreshTree,
   stopDirWatcher,
+  getActivePanel,
   SIDEBAR_IMAGE_MIME,
 } from "./sidebar.ts";
 import {
@@ -330,6 +331,19 @@ async function refreshGitAndSyncNow() {
   await doGitRefresh();
 }
 
+/** Git refresh after an autosave. An already-modified (unstaged) file stays
+ * modified after another save — only the line counts shown inside the git
+ * panel change — so skip the git process spawns while the panel is hidden. */
+function refreshGitAfterAutoSave(path: string) {
+  if (getActivePanel() !== "git") {
+    const root = getRootPath();
+    const rel = root && path.startsWith(root + "/") ? path.slice(root.length + 1) : path;
+    const entry = getStatusMap().get(rel);
+    if (entry && !entry.staged) return;
+  }
+  refreshGitAndSync();
+}
+
 /** Reload all open file-backed tabs from disk (after git ops that modify files). */
 async function reloadAllOpenTabs() {
   const fileTabs = getTabs().filter((t) => t.path);
@@ -359,6 +373,7 @@ initFileOps({
   getCurrentFilePath,
   loadContentAsTab,
   refreshGitAndSync,
+  refreshGitAfterAutoSave,
 });
 
 initCrawl({
@@ -730,6 +745,7 @@ if (gitPanelEl) {
       updateGitChangeCount(getChangeCount());
     },
     onFilesChanged: () => reloadAllOpenTabs(),
+    isVisible: () => getActivePanel() === "git",
   });
 }
 

--- a/ui/src/sidebar.ts
+++ b/ui/src/sidebar.ts
@@ -1,4 +1,4 @@
-import { createGitBadge, applyGitNameStyle } from "./git-panel.ts";
+import { createGitBadge, applyGitNameStyle, refresh as refreshGitPanel } from "./git-panel.ts";
 import { IMPORT_EXTENSIONS, convertFile } from "./file-ops.ts";
 import { submitBatch, pollBatch, saveBatchResults } from "./batch-import.ts";
 import {
@@ -613,9 +613,16 @@ function createNavButton(panel: SidebarPanel, label: string, svgIcon: string): H
   return btn;
 }
 
+export function getActivePanel(): SidebarPanel {
+  return activePanel;
+}
+
 export function switchPanel(panel: SidebarPanel) {
+  const wasActive = activePanel === panel;
   activePanel = panel;
   localStorage.setItem(windowKey(KEY_SIDEBAR_PANEL), panel);
+  // Stats and log are skipped while the git panel is hidden — refresh on open
+  if (panel === "git" && !wasActive) refreshGitPanel();
   // Update header title
   const titleEl = sidebarEl?.querySelector(".sidebar-title");
   if (titleEl) titleEl.textContent = panelTitle();


### PR DESCRIPTION
Closes #254

## Changes

Steady typing previously spawned ~4 git processes (`status`, two `--numstat` diffs, `log -10`) every few seconds via autosave → `refreshGitAndSync`, all serialized under `GIT_LOCK`.

- **Autosave skip**: autosaving a file that is already modified (unstaged) cannot change its status — only the line counts shown inside the git panel. While the panel is hidden, the refresh is skipped entirely, so the common case (typing into an already-dirty file) spawns **zero** git processes.
- **`include_stats` flag on `git_status`**: the two `git diff --numstat` processes only run when the git panel is visible (counts are only rendered there). The MCP bridge keeps full stats (default `true`).
- **`git log -10` skipped while hidden**: the commit log is also panel-only; switching to the git panel now triggers a fresh refresh so stats and log are up to date the moment they become visible (previously the panel could show a stale log until the next refresh anyway).

Status badges in the sidebar/tab UI still refresh as before whenever a file's status can actually change (new modification, stage/unstage, git ops, FS watcher events).

## Verification
- `cargo check` passes
- `vp check src/` and `tsc --noEmit` pass