### PR TITLE
refactor(mcp-server): consolidate duplicated HTTP boilerplate (-189 lines)

### DIFF
--- a/mcp-server-rs/src/bridge.rs
+++ b/mcp-server-rs/src/bridge.rs
@@ -81,6 +81,33 @@ impl BridgeClient {
         }
     }
 
+    /// Send a request and surface the bridge's `error` field as Err.
+    async fn request_json(
+        &self,
+        method: &str,
+        path: &str,
+        body: Option<serde_json::Value>,
+    ) -> Result<serde_json::Value, String> {
+        let json = self.request(method, path, body).await?.unwrap_or_default();
+        if let Some(err) = json.get("error").and_then(|v| v.as_str()) {
+            return Err(err.to_string());
+        }
+        Ok(json)
+    }
+
+    /// Like `request_json`, extracting a single string field from the response
+    /// (missing field -> empty string).
+    async fn request_str(
+        &self,
+        method: &str,
+        path: &str,
+        body: Option<serde_json::Value>,
+        field: &str,
+    ) -> Result<String, String> {
+        let json = self.request_json(method, path, body).await?;
+        Ok(json.get(field).and_then(|v| v.as_str()).unwrap_or("").to_string())
+    }
+
     pub async fn get_editor_content(&self) -> Result<String, String> {
         #[derive(Deserialize)]
         struct Resp {
@@ -128,12 +155,7 @@ impl BridgeClient {
     }
 
     pub async fn get_document_structure(&self) -> Result<serde_json::Value, String> {
-        let val = self.request("GET", "/editor/structure", None).await?;
-        let json = val.unwrap_or_default();
-        if json.get("error").is_some() {
-            return Err(json["error"].as_str().unwrap_or("Unknown error").to_string());
-        }
-        Ok(json)
+        self.request_json("GET", "/editor/structure", None).await
     }
 
     pub async fn get_tabs(&self) -> Result<Vec<TabInfo>, String> {
@@ -173,11 +195,7 @@ impl BridgeClient {
         if recursive {
             query.push_str("recursive=true");
         }
-        let val = self.request("GET", &query, None).await?;
-        let json = val.unwrap_or_default();
-        if let Some(err) = json.get("error").and_then(|v| v.as_str()) {
-            return Err(err.to_string());
-        }
+        let json = self.request_json("GET", &query, None).await?;
         #[derive(Deserialize)]
         struct Resp { entries: Vec<FileEntry> }
         let resp: Resp = serde_json::from_value(json).map_err(|e| e.to_string())?;
@@ -186,12 +204,7 @@ impl BridgeClient {
 
     pub async fn read_file(&self, path: &str) -> Result<String, String> {
         let query = format!("/files/read?path={}", urlencoding::encode(path));
-        let val = self.request("GET", &query, None).await?;
-        let json = val.unwrap_or_default();
-        if let Some(err) = json.get("error").and_then(|v| v.as_str()) {
-            return Err(err.to_string());
-        }
-        Ok(json.get("content").and_then(|v| v.as_str()).unwrap_or("").to_string())
+        self.request_str("GET", &query, None, "content").await
     }
 
     pub async fn search_files(&self, query_str: &str, path: Option<&str>) -> Result<Vec<FileEntry>, String> {
@@ -199,11 +212,7 @@ impl BridgeClient {
         if let Some(p) = path {
             query.push_str(&format!("&path={}", urlencoding::encode(p)));
         }
-        let val = self.request("GET", &query, None).await?;
-        let json = val.unwrap_or_default();
-        if let Some(err) = json.get("error").and_then(|v| v.as_str()) {
-            return Err(err.to_string());
-        }
+        let json = self.request_json("GET", &query, None).await?;
         #[derive(Deserialize)]
         struct Resp { matches: Vec<FileEntry> }
         let resp: Resp = serde_json::from_value(json).map_err(|e| e.to_string())?;
@@ -211,22 +220,12 @@ impl BridgeClient {
     }
 
     pub async fn git_status(&self) -> Result<GitStatus, String> {
-        let val = self.request("GET", "/git/status", None).await?;
-        let json = val.unwrap_or_default();
-        if let Some(err) = json.get("error").and_then(|v| v.as_str()) {
-            return Err(err.to_string());
-        }
+        let json = self.request_json("GET", "/git/status", None).await?;
         serde_json::from_value(json).map_err(|e| e.to_string())
     }
 
     async fn post_check_error(&self, path: &str, body: serde_json::Value) -> Result<(), String> {
-        let val = self.request("POST", path, Some(body)).await?;
-        if let Some(json) = val {
-            if let Some(err) = json.get("error").and_then(|v| v.as_str()) {
-                return Err(err.to_string());
-            }
-        }
-        Ok(())
+        self.request_json("POST", path, Some(body)).await.map(|_| ())
     }
 
     pub async fn create_file(&self, path: &str) -> Result<(), String> {
@@ -246,21 +245,11 @@ impl BridgeClient {
     }
 
     pub async fn copy_entry(&self, from: &str, to_dir: &str) -> Result<String, String> {
-        let val = self.request("POST", "/files/copy", Some(serde_json::json!({ "from": from, "to_dir": to_dir }))).await?;
-        let json = val.unwrap_or_default();
-        if let Some(err) = json.get("error").and_then(|v| v.as_str()) {
-            return Err(err.to_string());
-        }
-        Ok(json.get("path").and_then(|v| v.as_str()).unwrap_or("").to_string())
+        self.request_str("POST", "/files/copy", Some(serde_json::json!({ "from": from, "to_dir": to_dir })), "path").await
     }
 
     pub async fn duplicate_entry(&self, path: &str) -> Result<String, String> {
-        let val = self.request("POST", "/files/duplicate", Some(serde_json::json!({ "path": path }))).await?;
-        let json = val.unwrap_or_default();
-        if let Some(err) = json.get("error").and_then(|v| v.as_str()) {
-            return Err(err.to_string());
-        }
-        Ok(json.get("path").and_then(|v| v.as_str()).unwrap_or("").to_string())
+        self.request_str("POST", "/files/duplicate", Some(serde_json::json!({ "path": path })), "path").await
     }
 
     // --- Git write operations ---
@@ -274,42 +263,24 @@ impl BridgeClient {
     }
 
     pub async fn git_commit(&self, message: &str) -> Result<String, String> {
-        let val = self.request("POST", "/git/commit", Some(serde_json::json!({ "message": message }))).await?;
-        let json = val.unwrap_or_default();
-        if let Some(err) = json.get("error").and_then(|v| v.as_str()) {
-            return Err(err.to_string());
-        }
-        Ok(json.get("output").and_then(|v| v.as_str()).unwrap_or("").to_string())
-    }
-
-    async fn git_remote_op(&self, endpoint: &str) -> Result<String, String> {
-        let val = self.request("POST", endpoint, None).await?;
-        let json = val.unwrap_or_default();
-        if let Some(err) = json.get("error").and_then(|v| v.as_str()) {
-            return Err(err.to_string());
-        }
-        Ok(json.get("output").and_then(|v| v.as_str()).unwrap_or("").to_string())
+        self.request_str("POST", "/git/commit", Some(serde_json::json!({ "message": message })), "output").await
     }
 
     pub async fn git_push(&self) -> Result<String, String> {
-        self.git_remote_op("/git/push").await
+        self.request_str("POST", "/git/push", None, "output").await
     }
 
     pub async fn git_pull(&self) -> Result<String, String> {
-        self.git_remote_op("/git/pull").await
+        self.request_str("POST", "/git/pull", None, "output").await
     }
 
     pub async fn git_fetch(&self) -> Result<String, String> {
-        self.git_remote_op("/git/fetch").await
+        self.request_str("POST", "/git/fetch", None, "output").await
     }
 
     pub async fn git_diff(&self, path: &str, staged: bool) -> Result<String, String> {
-        let val = self.request("GET", &format!("/git/diff?path={}&staged={}", urlencoding::encode(path), staged), None).await?;
-        let json = val.unwrap_or_default();
-        if let Some(err) = json.get("error").and_then(|v| v.as_str()) {
-            return Err(err.to_string());
-        }
-        Ok(json.get("diff").and_then(|v| v.as_str()).unwrap_or("").to_string())
+        let query = format!("/git/diff?path={}&staged={}", urlencoding::encode(path), staged);
+        self.request_str("GET", &query, None, "diff").await
     }
 
     pub async fn git_discard(&self, path: &str) -> Result<(), String> {
@@ -325,11 +296,7 @@ impl BridgeClient {
             Some(l) => format!("/git/log?limit={}", l),
             None => "/git/log".to_string(),
         };
-        let val = self.request("GET", &query, None).await?;
-        let json = val.unwrap_or_default();
-        if let Some(err) = json.get("error").and_then(|v| v.as_str()) {
-            return Err(err.to_string());
-        }
+        let json = self.request_json("GET", &query, None).await?;
         #[derive(Deserialize)]
         struct Resp { entries: Vec<GitLogEntry> }
         let resp: Resp = serde_json::from_value(json).map_err(|e| e.to_string())?;
@@ -337,72 +304,39 @@ impl BridgeClient {
     }
 
     pub async fn git_revert(&self, commit_hash: &str) -> Result<String, String> {
-        let val = self.request("POST", "/git/revert", Some(serde_json::json!({ "commit_hash": commit_hash }))).await?;
-        let json = val.unwrap_or_default();
-        if let Some(err) = json.get("error").and_then(|v| v.as_str()) {
-            return Err(err.to_string());
-        }
-        Ok(json.get("output").and_then(|v| v.as_str()).unwrap_or("").to_string())
+        self.request_str("POST", "/git/revert", Some(serde_json::json!({ "commit_hash": commit_hash })), "output").await
     }
 
     // --- Crawl save ---
 
     pub async fn crawl_save(&self, pages: &[CrawlSavePage], base_dir: &str) -> Result<CrawlSaveResult, String> {
-        let val = self.request("POST", "/crawl/save", Some(serde_json::json!({
+        let json = self.request_json("POST", "/crawl/save", Some(serde_json::json!({
             "pages": pages,
             "base_dir": base_dir,
         }))).await?;
-        let json = val.unwrap_or_default();
-        if let Some(err) = json.get("error").and_then(|v| v.as_str()) {
-            return Err(err.to_string());
-        }
         serde_json::from_value(json).map_err(|e| e.to_string())
     }
 
     // --- Content & assets ---
 
     pub async fn download_image(&self, url: &str, dest_path: &str) -> Result<String, String> {
-        let val = self.request("POST", "/content/download-image", Some(serde_json::json!({
-            "url": url,
-            "dest_path": dest_path,
-        }))).await?;
-        let json = val.unwrap_or_default();
-        if let Some(err) = json.get("error").and_then(|v| v.as_str()) {
-            return Err(err.to_string());
-        }
-        Ok(json.get("path").and_then(|v| v.as_str()).unwrap_or("").to_string())
+        let body = serde_json::json!({ "url": url, "dest_path": dest_path });
+        self.request_str("POST", "/content/download-image", Some(body), "path").await
     }
 
     pub async fn fetch_page_title(&self, url: &str) -> Result<String, String> {
-        let val = self.request("POST", "/content/fetch-title", Some(serde_json::json!({
-            "url": url,
-        }))).await?;
-        let json = val.unwrap_or_default();
-        if let Some(err) = json.get("error").and_then(|v| v.as_str()) {
-            return Err(err.to_string());
-        }
-        Ok(json.get("title").and_then(|v| v.as_str()).unwrap_or("").to_string())
+        let body = serde_json::json!({ "url": url });
+        self.request_str("POST", "/content/fetch-title", Some(body), "title").await
     }
 
     // --- Tags ---
 
     pub async fn get_tags(&self) -> Result<serde_json::Value, String> {
-        let val = self.request("GET", "/tags/list", None).await?;
-        let json = val.unwrap_or_default();
-        if let Some(err) = json.get("error").and_then(|v| v.as_str()) {
-            return Err(err.to_string());
-        }
-        Ok(json)
+        self.request_json("GET", "/tags/list", None).await
     }
 
     pub async fn set_tags(&self, data: &serde_json::Value) -> Result<(), String> {
-        let val = self.request("POST", "/tags/set", Some(serde_json::json!({ "tags": data }))).await?;
-        if let Some(json) = val {
-            if let Some(err) = json.get("error").and_then(|v| v.as_str()) {
-                return Err(err.to_string());
-            }
-        }
-        Ok(())
+        self.request_json("POST", "/tags/set", Some(serde_json::json!({ "tags": data }))).await.map(|_| ())
     }
 
     // --- Git extended operations ---
@@ -412,30 +346,17 @@ impl BridgeClient {
     }
 
     pub async fn git_show(&self, commit_hash: &str) -> Result<String, String> {
-        let val = self.request("GET", &format!("/git/show?commit_hash={}", urlencoding::encode(commit_hash)), None).await?;
-        let json = val.unwrap_or_default();
-        if let Some(err) = json.get("error").and_then(|v| v.as_str()) {
-            return Err(err.to_string());
-        }
-        Ok(json.get("output").and_then(|v| v.as_str()).unwrap_or("").to_string())
+        let query = format!("/git/show?commit_hash={}", urlencoding::encode(commit_hash));
+        self.request_str("GET", &query, None, "output").await
     }
 
     pub async fn git_clone(&self, url: &str, dest: &str) -> Result<String, String> {
-        let val = self.request("POST", "/git/clone", Some(serde_json::json!({ "url": url, "dest": dest }))).await?;
-        let json = val.unwrap_or_default();
-        if let Some(err) = json.get("error").and_then(|v| v.as_str()) {
-            return Err(err.to_string());
-        }
-        Ok(json.get("output").and_then(|v| v.as_str()).unwrap_or("").to_string())
+        let body = serde_json::json!({ "url": url, "dest": dest });
+        self.request_str("POST", "/git/clone", Some(body), "output").await
     }
 
     pub async fn git_init(&self, path: &str) -> Result<String, String> {
-        let val = self.request("POST", "/git/init", Some(serde_json::json!({ "path": path }))).await?;
-        let json = val.unwrap_or_default();
-        if let Some(err) = json.get("error").and_then(|v| v.as_str()) {
-            return Err(err.to_string());
-        }
-        Ok(json.get("output").and_then(|v| v.as_str()).unwrap_or("").to_string())
+        self.request_str("POST", "/git/init", Some(serde_json::json!({ "path": path })), "output").await
     }
 
     // --- Window management ---

--- a/mcp-server-rs/src/tools.rs
+++ b/mcp-server-rs/src/tools.rs
@@ -423,6 +423,80 @@ impl McpTools {
         Ok(url)
     }
 
+    /// Call a Worker endpoint: resolve the URL, send the request, and surface
+    /// the Worker's `error` field on non-success status. Tolerates empty or
+    /// non-JSON bodies (e.g. DELETE responses) by returning Null.
+    async fn worker_call(
+        &self,
+        method: reqwest::Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        timeout_secs: u64,
+    ) -> Result<serde_json::Value, String> {
+        let worker_url = self.resolve_worker_url().await?;
+        let url = format!("{}{path}", worker_url.trim_end_matches('/'));
+        let mut req = self
+            .http
+            .request(method, &url)
+            .timeout(std::time::Duration::from_secs(timeout_secs));
+        if let Some(body) = body {
+            req = req.json(&body);
+        }
+        let response = req.send().await.map_err(|e| format!("Request failed: {e}"))?;
+        let status = response.status();
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|e| format!("Failed to read response: {e}"))?;
+        let data: serde_json::Value = serde_json::from_slice(&bytes).unwrap_or_default();
+        if !status.is_success() {
+            let err = data["error"].as_str().unwrap_or("Unknown error");
+            return Err(format!("Worker returned {status}: {err}"));
+        }
+        Ok(data)
+    }
+
+    /// Resolve an absolute path to a path relative to the project root
+    /// (used by the tag tools, which key files by relative path).
+    async fn resolve_rel_path(&self, path: &str) -> String {
+        let root = self.bridge.get_project_root().await.ok().flatten().unwrap_or_default();
+        if !root.is_empty() && path.starts_with(&root) {
+            path[root.len()..].trim_start_matches('/').to_string()
+        } else {
+            path.to_string()
+        }
+    }
+
+    /// GET a URL with `Accept: text/markdown` (Markdown for Agents).
+    /// Returns (content_type, x-markdown-tokens header, body).
+    async fn fetch_with_markdown_accept(
+        &self,
+        url: &str,
+    ) -> Result<(String, Option<String>, String), String> {
+        let response = self
+            .http
+            .get(url)
+            .header("Accept", "text/markdown")
+            .timeout(std::time::Duration::from_secs(30))
+            .send()
+            .await
+            .map_err(|e| e.to_string())?;
+
+        let content_type = response
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+        let tokens = response
+            .headers()
+            .get("x-markdown-tokens")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+        let body = response.text().await.map_err(|e| e.to_string())?;
+        Ok((content_type, tokens, body))
+    }
+
     // --- Editor Tools (require running app) ---
 
     #[tool(name = "get_editor_content", description = "Get current Markdown content from the editor", annotations(read_only_hint = true, open_world_hint = false, destructive_hint = false))]
@@ -463,27 +537,7 @@ impl McpTools {
         Parameters(params): Parameters<UrlParams>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
         let result = async {
-            let response = self
-                .http
-                .get(&params.url)
-                .header("Accept", "text/markdown")
-                .timeout(std::time::Duration::from_secs(30))
-                .send()
-                .await
-                .map_err(|e| e.to_string())?;
-
-            let content_type = response
-                .headers()
-                .get("content-type")
-                .and_then(|v| v.to_str().ok())
-                .unwrap_or("")
-                .to_string();
-            let tokens = response
-                .headers()
-                .get("x-markdown-tokens")
-                .and_then(|v| v.to_str().ok())
-                .map(|s| s.to_string());
-            let body = response.text().await.map_err(|e| e.to_string())?;
+            let (content_type, tokens, body) = self.fetch_with_markdown_accept(&params.url).await?;
 
             let is_markdown = content_type.contains("text/markdown");
             let mut info = if is_markdown {
@@ -542,22 +596,7 @@ impl McpTools {
     ) -> Result<CallToolResult, rmcp::ErrorData> {
         let result = async {
             // 1. Try Markdown for Agents (direct fetch)
-            let response = self
-                .http
-                .get(&params.url)
-                .header("Accept", "text/markdown")
-                .timeout(std::time::Duration::from_secs(30))
-                .send()
-                .await
-                .map_err(|e| e.to_string())?;
-
-            let content_type = response
-                .headers()
-                .get("content-type")
-                .and_then(|v| v.to_str().ok())
-                .unwrap_or("")
-                .to_string();
-            let body = response.text().await.map_err(|e| e.to_string())?;
+            let (content_type, _, body) = self.fetch_with_markdown_accept(&params.url).await?;
 
             if content_type.contains("text/markdown") {
                 return Ok(format!("--- Markdown for Agents ---\n\n{body}"));
@@ -1355,13 +1394,7 @@ impl McpTools {
     ) -> Result<CallToolResult, rmcp::ErrorData> {
         match self.bridge.get_tags().await {
             Ok(data) => {
-                // Resolve relative path from project root
-                let root = self.bridge.get_project_root().await.ok().flatten().unwrap_or_default();
-                let rel_path = if !root.is_empty() && params.path.starts_with(&root) {
-                    params.path[root.len()..].trim_start_matches('/').to_string()
-                } else {
-                    params.path.clone()
-                };
+                let rel_path = self.resolve_rel_path(&params.path).await;
                 let tags = data.get("files")
                     .and_then(|f| f.get(&rel_path))
                     .cloned()
@@ -1385,12 +1418,7 @@ impl McpTools {
             Err(e) => return Ok(CallToolResult::error(vec![Content::text(e)])),
         };
 
-        let root = self.bridge.get_project_root().await.ok().flatten().unwrap_or_default();
-        let rel_path = if !root.is_empty() && params.path.starts_with(&root) {
-            params.path[root.len()..].trim_start_matches('/').to_string()
-        } else {
-            params.path.clone()
-        };
+        let rel_path = self.resolve_rel_path(&params.path).await;
 
         // Validate that all tags exist
         if let Some(tag_defs) = data.get("tags").and_then(|t| t.as_object()) {
@@ -1511,9 +1539,6 @@ impl McpTools {
         Parameters(params): Parameters<IndexDocumentsParams>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
         let result = async {
-            let worker_url = self.resolve_worker_url().await?;
-            let embed_url = format!("{}/embed", worker_url.trim_end_matches('/'));
-
             let documents: Vec<serde_json::Value> = params.documents.iter().map(|d| {
                 let mut doc = serde_json::json!({ "id": d.id, "content": d.content });
                 if let Some(ref meta) = d.metadata {
@@ -1522,26 +1547,13 @@ impl McpTools {
                 doc
             }).collect();
 
-            let response = self
-                .http
-                .post(&embed_url)
-                .timeout(std::time::Duration::from_secs(60))
-                .json(&serde_json::json!({ "documents": documents }))
-                .send()
-                .await
-                .map_err(|e| format!("Request failed: {e}"))?;
-
-            let status = response.status();
-            let data: serde_json::Value = response.json().await.map_err(|e| format!("Failed to parse response: {e}"))?;
-
-            if !status.is_success() {
-                let err = data["error"].as_str().unwrap_or("Unknown error");
-                return Err(format!("Worker returned {status}: {err}"));
-            }
+            let data = self
+                .worker_call(reqwest::Method::POST, "/embed", Some(serde_json::json!({ "documents": documents })), 60)
+                .await?;
 
             let indexed = data["indexed"].as_u64().unwrap_or(0);
             let chunks = data["chunks"].as_u64().unwrap_or(0);
-            Ok(format!("Indexed {indexed} documents ({chunks} chunks)"))
+            Ok::<_, String>(format!("Indexed {indexed} documents ({chunks} chunks)"))
         }
         .await;
 
@@ -1557,25 +1569,9 @@ impl McpTools {
         Parameters(params): Parameters<RemoveDocumentParams>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
         let result = async {
-            let worker_url = self.resolve_worker_url().await?;
-            let delete_url = format!("{}/embed/{}", worker_url.trim_end_matches('/'), urlencoding::encode(&params.id));
-
-            let response = self
-                .http
-                .delete(&delete_url)
-                .timeout(std::time::Duration::from_secs(30))
-                .send()
-                .await
-                .map_err(|e| format!("Request failed: {e}"))?;
-
-            let status = response.status();
-            if !status.is_success() {
-                let data: serde_json::Value = response.json().await.map_err(|e| e.to_string())?;
-                let err = data["error"].as_str().unwrap_or("Unknown error");
-                return Err(format!("Worker returned {status}: {err}"));
-            }
-
-            Ok(format!("Removed document: {}", params.id))
+            let path = format!("/embed/{}", urlencoding::encode(&params.id));
+            self.worker_call(reqwest::Method::DELETE, &path, None, 30).await?;
+            Ok::<_, String>(format!("Removed document: {}", params.id))
         }
         .await;
 
@@ -1591,9 +1587,6 @@ impl McpTools {
         Parameters(params): Parameters<PublishDocumentParams>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
         let result = async {
-            let worker_url = self.resolve_worker_url().await?;
-            let publish_url = format!("{}/publish", worker_url.trim_end_matches('/'));
-
             let mut body = serde_json::json!({
                 "key": params.key,
                 "content": params.content,
@@ -1605,27 +1598,12 @@ impl McpTools {
                 }
             }
 
-            let response = self
-                .http
-                .put(&publish_url)
-                .timeout(std::time::Duration::from_secs(30))
-                .json(&body)
-                .send()
-                .await
-                .map_err(|e| format!("Request failed: {e}"))?;
-
-            let status = response.status();
-            let data: serde_json::Value = response.json().await.map_err(|e| format!("Failed to parse response: {e}"))?;
-
-            if !status.is_success() {
-                let err = data["error"].as_str().unwrap_or("Unknown error");
-                return Err(format!("Worker returned {status}: {err}"));
-            }
+            let data = self.worker_call(reqwest::Method::PUT, "/publish", Some(body), 30).await?;
 
             let url = data["url"].as_str().unwrap_or("unknown");
             let expires = data["expiresAt"].as_str();
             match expires {
-                Some(exp) => Ok(format!("Published: {url}\nExpires: {exp}")),
+                Some(exp) => Ok::<_, String>(format!("Published: {url}\nExpires: {exp}")),
                 None => Ok(format!("Published (permanent): {url}")),
             }
         }
@@ -1643,25 +1621,9 @@ impl McpTools {
         Parameters(params): Parameters<UnpublishDocumentParams>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
         let result = async {
-            let worker_url = self.resolve_worker_url().await?;
-            let delete_url = format!("{}/publish/{}", worker_url.trim_end_matches('/'), urlencoding::encode(&params.key));
-
-            let response = self
-                .http
-                .delete(&delete_url)
-                .timeout(std::time::Duration::from_secs(30))
-                .send()
-                .await
-                .map_err(|e| format!("Request failed: {e}"))?;
-
-            let status = response.status();
-            if !status.is_success() {
-                let data: serde_json::Value = response.json().await.map_err(|e| e.to_string())?;
-                let err = data["error"].as_str().unwrap_or("Unknown error");
-                return Err(format!("Worker returned {status}: {err}"));
-            }
-
-            Ok(format!("Unpublished: {}", params.key))
+            let path = format!("/publish/{}", urlencoding::encode(&params.key));
+            self.worker_call(reqwest::Method::DELETE, &path, None, 30).await?;
+            Ok::<_, String>(format!("Unpublished: {}", params.key))
         }
         .await;
 
@@ -1674,30 +1636,13 @@ impl McpTools {
     #[tool(name = "list_published", description = "List all published documents in R2 storage. Returns key, size, and upload timestamp for each.", annotations(read_only_hint = true, open_world_hint = true, destructive_hint = false))]
     async fn list_published(&self) -> Result<CallToolResult, rmcp::ErrorData> {
         let result = async {
-            let worker_url = self.resolve_worker_url().await?;
-            let list_url = format!("{}/published", worker_url.trim_end_matches('/'));
-
-            let response = self
-                .http
-                .get(&list_url)
-                .timeout(std::time::Duration::from_secs(30))
-                .send()
-                .await
-                .map_err(|e| format!("Request failed: {e}"))?;
-
-            let status = response.status();
-            let data: serde_json::Value = response.json().await.map_err(|e| format!("Failed to parse response: {e}"))?;
-
-            if !status.is_success() {
-                let err = data["error"].as_str().unwrap_or("Unknown error");
-                return Err(format!("Worker returned {status}: {err}"));
-            }
+            let data = self.worker_call(reqwest::Method::GET, "/published", None, 30).await?;
 
             let files = data["files"].as_array();
             match files {
                 Some(arr) if !arr.is_empty() => {
                     let json = serde_json::to_string_pretty(&data["files"]).unwrap_or_default();
-                    Ok(format!("{} published documents\n\n{json}", arr.len()))
+                    Ok::<_, String>(format!("{} published documents\n\n{json}", arr.len()))
                 }
                 _ => Ok("No published documents.".to_string()),
             }
@@ -1716,32 +1661,16 @@ impl McpTools {
         Parameters(params): Parameters<SubmitBatchParams>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
         let result = async {
-            let worker_url = self.resolve_worker_url().await?;
-            let batch_url = format!("{}/batch", worker_url.trim_end_matches('/'));
-
             let files: Vec<serde_json::Value> = params.files.iter().map(|f| {
                 serde_json::json!({ "name": f.name, "content": f.content })
             }).collect();
 
-            let response = self
-                .http
-                .post(&batch_url)
-                .timeout(std::time::Duration::from_secs(30))
-                .json(&serde_json::json!({ "files": files }))
-                .send()
-                .await
-                .map_err(|e| format!("Request failed: {e}"))?;
-
-            let status = response.status();
-            let data: serde_json::Value = response.json().await.map_err(|e| format!("Failed to parse response: {e}"))?;
-
-            if !status.is_success() {
-                let err = data["error"].as_str().unwrap_or("Unknown error");
-                return Err(format!("Worker returned {status}: {err}"));
-            }
+            let data = self
+                .worker_call(reqwest::Method::POST, "/batch", Some(serde_json::json!({ "files": files })), 30)
+                .await?;
 
             let batch_id = data["batch_id"].as_str().unwrap_or("unknown");
-            Ok(format!("Batch submitted. batch_id: {batch_id}\n\nUse get_batch_status with this batch_id to poll for results."))
+            Ok::<_, String>(format!("Batch submitted. batch_id: {batch_id}\n\nUse get_batch_status with this batch_id to poll for results."))
         }
         .await;
 
@@ -1757,27 +1686,9 @@ impl McpTools {
         Parameters(params): Parameters<GetBatchStatusParams>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
         let result = async {
-            let worker_url = self.resolve_worker_url().await?;
-            let status_url = format!("{}/batch/{}", worker_url.trim_end_matches('/'), params.batch_id);
-
-            let response = self
-                .http
-                .get(&status_url)
-                .timeout(std::time::Duration::from_secs(30))
-                .send()
-                .await
-                .map_err(|e| format!("Request failed: {e}"))?;
-
-            let status = response.status();
-            let data: serde_json::Value = response.json().await.map_err(|e| format!("Failed to parse response: {e}"))?;
-
-            if !status.is_success() {
-                let err = data["error"].as_str().unwrap_or("Unknown error");
-                return Err(format!("Worker returned {status}: {err}"));
-            }
-
-            let json = serde_json::to_string_pretty(&data).unwrap_or_default();
-            Ok(json)
+            let path = format!("/batch/{}", params.batch_id);
+            let data = self.worker_call(reqwest::Method::GET, &path, None, 30).await?;
+            Ok::<_, String>(serde_json::to_string_pretty(&data).unwrap_or_default())
         }
         .await;
 
@@ -1847,33 +1758,12 @@ impl McpTools {
         Parameters(params): Parameters<SemanticSearchParams>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
         let result = async {
-            let worker_url = self.resolve_worker_url().await?;
-            let search_url = format!("{}/search", worker_url.trim_end_matches('/'));
-
             let body = serde_json::json!({
                 "query": params.query,
                 "limit": params.limit.unwrap_or(10),
             });
 
-            let response = self
-                .http
-                .post(&search_url)
-                .timeout(std::time::Duration::from_secs(30))
-                .json(&body)
-                .send()
-                .await
-                .map_err(|e| format!("Request failed: {e}"))?;
-
-            let status = response.status();
-            let data: serde_json::Value = response
-                .json()
-                .await
-                .map_err(|e| format!("Failed to parse response: {e}"))?;
-
-            if !status.is_success() {
-                let err = data["error"].as_str().unwrap_or("Unknown error");
-                return Err(format!("Worker returned {status}: {err}"));
-            }
+            let data = self.worker_call(reqwest::Method::POST, "/search", Some(body), 30).await?;
 
             let results = data["results"].as_array();
             match results {
@@ -1886,7 +1776,7 @@ impl McpTools {
                         let score = r["score"].as_f64().unwrap_or(0.0);
                         output.push_str(&format!("- **{}** (score: {:.2})\n", doc_id, score));
                     }
-                    Ok(output)
+                    Ok::<_, String>(output)
                 }
                 _ => Ok("No results found.".to_string()),
             }


### PR DESCRIPTION
Closes #256

## Changes

**Worker-call boilerplate** (`tools.rs`)
- New `worker_call(method, path, body, timeout_secs)` helper: resolve-URL → request → status check → `error`-field extraction. Used by all 8 worker-direct tools (`index_documents`, `remove_document`, `publish_document`, `unpublish_document`, `list_published`, `submit_batch`, `get_batch_status`, `semantic_search`).
- It tolerates empty/non-JSON bodies (DELETE responses), so the two slightly different copies (parse-always vs parse-on-failure) collapse into one.

**Bridge response handling** (`bridge.rs`)
- New `request_json()` (request + surface bridge `error` field) and `request_str()` (extract a single string field) helpers, generalizing the old `post_check_error` / `git_remote_op` pattern.
- ~15 methods rewritten (`git_commit`, `git_push/pull/fetch`, `git_diff`, `git_show`, `git_clone`, `git_init`, `git_revert`, `copy_entry`, `duplicate_entry`, `download_image`, `fetch_page_title`, `read_file`, `get_tags`, `set_tags`, …).

**Minor duplications from the issue**
- `resolve_rel_path()` shared by `get_file_tags` / `set_file_tags`
- `fetch_with_markdown_accept()` shared by `fetch_markdown` / `get_markdown`

Net **-189 lines** with unified error messages. Tool-visible behavior is unchanged.

## Verification
- `cargo check` passes (only the pre-existing `tool_router` dead-code warning remains)