### PR TITLE
refactor: small duplication cleanups across app and backend

### DIFF
--- a/src-tauri/src/bridge.rs
+++ b/src-tauri/src/bridge.rs
@@ -715,7 +715,6 @@ async fn git_commit(
 }
 
 async fn git_remote_op(
-    _state: &BridgeState,
     op: impl std::future::Future<Output = crate::error::Result<String>>,
 ) -> Json<serde_json::Value> {
     match op.await {
@@ -729,7 +728,7 @@ async fn git_push(State(state): State<Arc<BridgeState>>) -> Json<serde_json::Val
         Ok(p) => p,
         Err(e) => return e,
     };
-    git_remote_op(&state, commands::git_push(repo_path)).await
+    git_remote_op(commands::git_push(repo_path)).await
 }
 
 async fn git_pull(State(state): State<Arc<BridgeState>>) -> Json<serde_json::Value> {
@@ -737,7 +736,7 @@ async fn git_pull(State(state): State<Arc<BridgeState>>) -> Json<serde_json::Val
         Ok(p) => p,
         Err(e) => return e,
     };
-    git_remote_op(&state, commands::git_pull(repo_path)).await
+    git_remote_op(commands::git_pull(repo_path)).await
 }
 
 async fn git_fetch(State(state): State<Arc<BridgeState>>) -> Json<serde_json::Value> {
@@ -745,7 +744,7 @@ async fn git_fetch(State(state): State<Arc<BridgeState>>) -> Json<serde_json::Va
         Ok(p) => p,
         Err(e) => return e,
     };
-    git_remote_op(&state, commands::git_fetch(repo_path)).await
+    git_remote_op(commands::git_fetch(repo_path)).await
 }
 
 // --- Git diff/discard/log/revert handlers ---

--- a/src-tauri/src/commands/web.rs
+++ b/src-tauri/src/commands/web.rs
@@ -54,7 +54,7 @@ pub(crate) async fn worker_request<T: DeserializeOwned + HasWorkerError>(
 /// Must match WORKER_VERSION in worker/src/config.ts.
 const EXPECTED_WORKER_VERSION: u32 = 9;
 
-#[derive(Serialize)]
+#[derive(Serialize, Default)]
 pub struct WorkerStatus {
     pub reachable: bool,
     pub convert_available: bool,
@@ -73,23 +73,13 @@ pub struct WorkerStatus {
 impl WorkerStatus {
     fn unreachable(error: String) -> Self {
         Self {
-            reachable: false,
-            convert_available: false,
-            render_available: false,
-            json_available: false,
-            crawl_available: false,
-            cache_available: false,
-            batch_available: false,
-            publish_available: false,
-            search_available: false,
-            worker_version: None,
-            update_available: false,
             error: Some(error),
+            ..Default::default()
         }
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Default)]
 struct HealthCapabilities {
     convert: Option<bool>,
     render: Option<bool>,
@@ -119,16 +109,7 @@ pub async fn test_worker_url(
         Ok(resp) if resp.status().is_success() => {
             match resp.json::<HealthResponse>().await {
                 Ok(body) => {
-                    let caps = body.capabilities.unwrap_or(HealthCapabilities {
-                        convert: None,
-                        render: None,
-                        json: None,
-                        crawl: None,
-                        cache: None,
-                        batch: None,
-                        publish: None,
-                        search: None,
-                    });
+                    let caps = body.capabilities.unwrap_or_default();
                     let version = body.version;
                     let update_available = match version {
                         Some(v) => v < EXPECTED_WORKER_VERSION,
@@ -151,33 +132,16 @@ pub async fn test_worker_url(
                 }
                 Err(e) => WorkerStatus {
                     reachable: true,
-                    convert_available: false,
-                    render_available: false,
-                    json_available: false,
-                    crawl_available: false,
-                    cache_available: false,
-                    batch_available: false,
-                    publish_available: false,
-                    search_available: false,
-                    worker_version: None,
                     update_available: true,
                     error: Some(format!("Unexpected response format: {e}")),
+                    ..Default::default()
                 }
             }
         }
         Ok(resp) => WorkerStatus {
             reachable: true,
-            convert_available: false,
-            render_available: false,
-            json_available: false,
-            crawl_available: false,
-            cache_available: false,
-            batch_available: false,
-            publish_available: false,
-            search_available: false,
-            worker_version: None,
-            update_available: false,
             error: Some(format!("Worker returned status {}", resp.status())),
+            ..Default::default()
         },
         Err(e) => WorkerStatus::unreachable(format!("Cannot reach worker: {e}")),
     })
@@ -510,6 +474,7 @@ pub fn detect_file_is_image(file_path: String) -> Result<bool> {
     Ok(mime_from_extension(ext).is_some_and(|m| m.starts_with("image/")))
 }
 
+/// MIME map (sync with mcp-server-rs/src/tools.rs and worker SUPPORTED_TYPES)
 fn mime_from_extension(ext: &str) -> Option<&'static str> {
     match ext.to_lowercase().as_str() {
         "pdf" => Some("application/pdf"),

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -12,7 +12,6 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tauri::{Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
 use tauri_plugin_cli::CliExt;
-use tauri_plugin_store::StoreExt;
 
 /// Resolve file path strings to absolute paths, filtering to files that exist.
 fn resolve_file_paths<'a>(
@@ -89,20 +88,16 @@ fn main() {
             bridge::start(app.handle().clone(), editor_states.clone());
 
             // Restore additional windows from session registry
-            if let Ok(store) = app.handle().store("window-registry.json") {
-                if let Some(val) = store.get("windows") {
-                    if let Ok(entries) = serde_json::from_value::<Vec<commands::WindowRegistryEntry>>(val.clone()) {
-                        for entry in entries.iter().filter(|e| e.label != "main") {
-                            let url = WebviewUrl::App("index.html".into());
-                            let mut builder = WebviewWindowBuilder::new(app, &entry.label, url)
-                                .title("MarkUpsideDown")
-                                .inner_size(entry.width, entry.height);
-                            if let (Some(x), Some(y)) = (entry.x, entry.y) {
-                                builder = builder.position(x, y);
-                            }
-                            let _ = builder.build();
-                        }
+            if let Ok(entries) = commands::load_window_registry(app.handle().clone()) {
+                for entry in entries.iter().filter(|e| e.label != "main") {
+                    let url = WebviewUrl::App("index.html".into());
+                    let mut builder = WebviewWindowBuilder::new(app, &entry.label, url)
+                        .title("MarkUpsideDown")
+                        .inner_size(entry.width, entry.height);
+                    if let (Some(x), Some(y)) = (entry.x, entry.y) {
+                        builder = builder.position(x, y);
                     }
+                    let _ = builder.build();
                 }
             }
 
@@ -207,15 +202,10 @@ fn main() {
                     // Remove closed window from registry (if app stays open)
                     if remaining > 1 {
                         let label = window.label().to_string();
-                        if let Ok(store) = window.app_handle().store("window-registry.json") {
-                            if let Some(val) = store.get("windows") {
-                                if let Ok(mut entries) = serde_json::from_value::<Vec<commands::WindowRegistryEntry>>(val.clone()) {
-                                    entries.retain(|e| e.label != label);
-                                    if let Ok(json) = serde_json::to_value(&entries) {
-                                        store.set("windows", json);
-                                    }
-                                }
-                            }
+                        let handle = window.app_handle().clone();
+                        if let Ok(mut entries) = commands::load_window_registry(handle.clone()) {
+                            entries.retain(|e| e.label != label);
+                            let _ = commands::save_window_registry(handle, entries);
                         }
                     }
 

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -1,11 +1,13 @@
 use serde_json::json;
-use tauri::menu::{Menu, MenuEvent, MenuItem, SubmenuBuilder};
+use tauri::menu::{Menu, MenuEvent, MenuItem, PredefinedMenuItem, Submenu, SubmenuBuilder};
 use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder, Wry};
 use tauri_plugin_store::StoreExt;
 
 const STORE_FILE: &str = "recent-files.json";
 const STORE_KEY: &str = "recent";
 const MAX_RECENT: usize = 10;
+const FILE_MENU_ID: &str = "file_menu";
+const RECENT_SUBMENU_ID: &str = "open_recent";
 
 pub fn build(handle: &AppHandle) -> tauri::Result<Menu<Wry>> {
     let recent_files = get_recent_files(handle);
@@ -24,42 +26,12 @@ pub fn build(handle: &AppHandle) -> tauri::Result<Menu<Wry>> {
         .build()?;
 
     // Open Recent submenu
-    let mut recent_builder = SubmenuBuilder::new(handle, "Open Recent");
-    if recent_files.is_empty() {
-        recent_builder = recent_builder.item(&MenuItem::with_id(
-            handle,
-            "no_recent",
-            "No Recent Files",
-            false,
-            None::<&str>,
-        )?);
-    } else {
-        for (i, path) in recent_files.iter().enumerate() {
-            let label = std::path::Path::new(path)
-                .file_name()
-                .map(|n| n.to_string_lossy().to_string())
-                .unwrap_or_else(|| path.clone());
-            recent_builder = recent_builder.item(&MenuItem::with_id(
-                handle,
-                format!("recent_{i}"),
-                label.as_str(),
-                true,
-                None::<&str>,
-            )?);
-        }
-        recent_builder = recent_builder.separator();
-        recent_builder = recent_builder.item(&MenuItem::with_id(
-            handle,
-            "clear_recent",
-            "Clear Recent",
-            true,
-            None::<&str>,
-        )?);
-    }
-    let recent_submenu = recent_builder.build()?;
+    let recent_submenu =
+        SubmenuBuilder::with_id(handle, RECENT_SUBMENU_ID, "Open Recent").build()?;
+    populate_recent_submenu(handle, &recent_submenu, &recent_files)?;
 
     // File menu
-    let file_menu = SubmenuBuilder::new(handle, "File")
+    let file_menu = SubmenuBuilder::with_id(handle, FILE_MENU_ID, "File")
         .item(&MenuItem::with_id(
             handle,
             "new_window",
@@ -87,6 +59,49 @@ pub fn build(handle: &AppHandle) -> tauri::Result<Menu<Wry>> {
     Menu::with_items(handle, &[&app_menu, &file_menu, &edit_menu])
 }
 
+/// Replace the contents of the "Open Recent" submenu with `files`.
+fn populate_recent_submenu(
+    handle: &AppHandle,
+    submenu: &Submenu<Wry>,
+    files: &[String],
+) -> tauri::Result<()> {
+    while matches!(submenu.remove_at(0), Ok(Some(_))) {}
+
+    if files.is_empty() {
+        submenu.append(&MenuItem::with_id(
+            handle,
+            "no_recent",
+            "No Recent Files",
+            false,
+            None::<&str>,
+        )?)?;
+        return Ok(());
+    }
+
+    for (i, path) in files.iter().enumerate() {
+        let label = std::path::Path::new(path)
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| path.clone());
+        submenu.append(&MenuItem::with_id(
+            handle,
+            format!("recent_{i}"),
+            label.as_str(),
+            true,
+            None::<&str>,
+        )?)?;
+    }
+    submenu.append(&PredefinedMenuItem::separator(handle)?)?;
+    submenu.append(&MenuItem::with_id(
+        handle,
+        "clear_recent",
+        "Clear Recent",
+        true,
+        None::<&str>,
+    )?)?;
+    Ok(())
+}
+
 fn get_recent_files(handle: &AppHandle) -> Vec<String> {
     let Ok(store) = handle.store(STORE_FILE) else {
         return vec![];
@@ -101,6 +116,18 @@ fn update_recent(handle: &AppHandle, files: &[String]) {
     if let Ok(store) = handle.store(STORE_FILE) {
         store.set(STORE_KEY, json!(files));
     }
+    // Update just the Open Recent submenu instead of rebuilding and
+    // replacing the entire native menu on every file open.
+    let recent_submenu = handle
+        .menu()
+        .and_then(|m| m.get(FILE_MENU_ID))
+        .and_then(|file| file.as_submenu().and_then(|f| f.get(RECENT_SUBMENU_ID)))
+        .and_then(|kind| kind.as_submenu().cloned());
+    if let Some(submenu) = recent_submenu {
+        let _ = populate_recent_submenu(handle, &submenu, files);
+        return;
+    }
+    // Fallback: rebuild the whole menu
     if let Ok(menu) = build(handle) {
         let _ = handle.set_menu(menu);
     }

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -53,6 +53,7 @@ import {
   isTabDirty,
   markTabSaved,
   updateTabPath,
+  type Tab,
   closeTabsByPath,
   closeTabsUnderDir,
   setTabsProjectRoot,
@@ -333,21 +334,7 @@ async function refreshGitAndSyncNow() {
 /** Reload all open file-backed tabs from disk (after git ops that modify files). */
 async function reloadAllOpenTabs() {
   const fileTabs = getTabs().filter((t) => t.path);
-  const results = await Promise.allSettled(
-    fileTabs.map((tab) => invoke<string>("read_text_file", { path: tab.path! })),
-  );
-  const activeId = getActiveTab()?.id;
-  for (let i = 0; i < fileTabs.length; i++) {
-    const r = results[i];
-    if (r.status !== "fulfilled") continue;
-    const tab = fileTabs[i];
-    tab.content = r.value;
-    tab.savedContent = r.value;
-    markTabSaved(tab.id);
-    if (tab.id === activeId) {
-      loadContent(r.value, tab.path);
-    }
-  }
+  await Promise.allSettled(fileTabs.map((tab) => reloadTabFromDisk(tab.path!)));
   refreshTree();
 }
 
@@ -382,10 +369,8 @@ initMcpSync({
   refreshTree,
 });
 
-// --- Initial render ---
-
-renderPreview(editor.state.doc.toString()).catch(() => {});
-updateStatus(editor.state);
+// Initial render of the welcome document happens after initTabs() below —
+// when a tab is restored, its activation renders instead.
 
 // --- Toolbar Actions ---
 
@@ -717,14 +702,7 @@ initSidebar(sidebarEl, {
 const gitPanelEl = getGitPanelEl();
 if (gitPanelEl) {
   initGitPanel(gitPanelEl, {
-    onOpen: async (filePath: string) => {
-      try {
-        const content = await invoke<string>("read_text_file", { path: filePath });
-        loadContentAsTab(content, filePath);
-      } catch (e) {
-        statusEl.textContent = `Open failed: ${e}`;
-      }
-    },
+    onOpen: openFileByPath,
     onRefresh: () => {
       setGitStatus(getStatusMap());
       updateGitChangeCount(getChangeCount());
@@ -865,16 +843,20 @@ const tabBarEl = document.getElementById("tab-bar")!;
 
 const { confirm: confirmDialog } = window.__TAURI__.dialog;
 
-async function reloadTabFromDisk(path: string) {
-  const content = await invoke<string>("read_text_file", { path });
-  const tab = getTabByPath(path);
-  if (!tab) return;
+/** Apply freshly-read disk content to a tab (and the editor when active). */
+function applyDiskContent(tab: Tab, content: string) {
   tab.content = content;
   tab.savedContent = content;
   markTabSaved(tab.id);
   if (tab.id === getActiveTab()?.id) {
-    loadContent(content, path);
+    loadContent(content, tab.path);
   }
+}
+
+async function reloadTabFromDisk(path: string) {
+  const content = await invoke<string>("read_text_file", { path });
+  const tab = getTabByPath(path);
+  if (tab) applyDiskContent(tab, content);
 }
 
 initFileWatcher({
@@ -912,12 +894,7 @@ async function reloadTab(tab: { content: string; path: string | null; id: string
 }
 
 initTabs(tabBarEl, {
-  onSwitch: (tab: {
-    content: string;
-    path: string | null;
-    id: string;
-    savedContent: string | null;
-  }) => {
+  onSwitch: (tab: Tab) => {
     autoSave();
     loadContent(tab.content, tab.path);
     // Check if file changed on disk since last load (catches missed watcher events)
@@ -925,10 +902,7 @@ initTabs(tabBarEl, {
       invoke<string>("read_text_file", { path: tab.path })
         .then((diskContent) => {
           if (diskContent !== tab.savedContent && tab.id === getActiveTab()?.id) {
-            tab.content = diskContent;
-            tab.savedContent = diskContent;
-            markTabSaved(tab.id);
-            loadContent(diskContent, tab.path);
+            applyDiskContent(tab, diskContent);
           }
         })
         .catch(() => {});
@@ -950,6 +924,13 @@ initTabs(tabBarEl, {
 // Start watching all previously open file-backed tabs
 for (const tab of getTabs()) {
   if (tab.path) startWatching(tab.path);
+}
+
+// Initial render — when a tab was restored above its activation already
+// rendered, so only the welcome document needs an explicit first render.
+if (!getActiveTab()) {
+  renderPreview(editor.state.doc.toString()).catch(() => {});
+  updateStatus(editor.state);
 }
 
 // Append editor fold button to editor-header (stays at right edge)

--- a/ui/src/settings.ts
+++ b/ui/src/settings.ts
@@ -231,6 +231,18 @@ function renderSetupProgress(container: HTMLElement, stepStates: Record<string, 
   }).join("");
 }
 
+/** Create optional Cloudflare resources and aggregate per-resource errors. */
+async function setupResources(
+  accountId: string,
+): Promise<{ resources: ResourceFlags; failed: string[] }> {
+  const result = await invoke<ResourceSetupResult>("setup_cloudflare_resources", { accountId });
+  const failed: string[] = [];
+  if (result.r2_error) failed.push(`R2: ${result.r2_error}`);
+  if (result.queue_error) failed.push(`Queue: ${result.queue_error}`);
+  if (result.vectorize_error) failed.push(`Vectorize: ${result.vectorize_error}`);
+  return { resources: result.resources, failed };
+}
+
 async function startAutoSetup(
   progressContainer: HTMLElement,
   urlInput: HTMLInputElement,
@@ -307,12 +319,8 @@ async function startAutoSetup(
     vectorize: false,
   };
   try {
-    const result = await invoke<ResourceSetupResult>("setup_cloudflare_resources", { accountId });
-    resourceFlags = result.resources;
-    const failed: string[] = [];
-    if (result.r2_error) failed.push(`R2: ${result.r2_error}`);
-    if (result.queue_error) failed.push(`Queue: ${result.queue_error}`);
-    if (result.vectorize_error) failed.push(`Vectorize: ${result.vectorize_error}`);
+    const { resources, failed } = await setupResources(accountId);
+    resourceFlags = resources;
     if (failed.length === 3) {
       update("resources", "error");
       showSetupMessage(
@@ -844,14 +852,8 @@ export function showSettings({
       };
       if (resolvedAccountId) {
         try {
-          const res = await invoke<ResourceSetupResult>("setup_cloudflare_resources", {
-            accountId: resolvedAccountId,
-          });
-          updateResources = res.resources;
-          const failed: string[] = [];
-          if (res.r2_error) failed.push(`R2: ${res.r2_error}`);
-          if (res.queue_error) failed.push(`Queue: ${res.queue_error}`);
-          if (res.vectorize_error) failed.push(`Vectorize: ${res.vectorize_error}`);
+          const { resources, failed } = await setupResources(resolvedAccountId);
+          updateResources = resources;
           if (failed.length > 0) {
             updateResult.className = "settings-test-result test-warn";
             updateResult.textContent = `Some resources failed: ${failed.join(", ")}`;
@@ -1059,17 +1061,7 @@ function renderClaudeDesktopCodeTab(container: HTMLElement, binaryPath: string, 
       ⚠ The config contains your secret Worker URL. Do not commit <code>.mcp.json</code> to public repositories — add it to <code>.gitignore</code>.
     </div>
   `;
-  for (const btn of container.querySelectorAll<HTMLButtonElement>(".settings-mcp-copy-btn")) {
-    btn.addEventListener("click", async () => {
-      const text = btn.dataset.copyText || "";
-      await navigator.clipboard.writeText(text);
-      const original = btn.textContent;
-      btn.textContent = "Copied!";
-      setTimeout(() => {
-        btn.textContent = original;
-      }, 1500);
-    });
-  }
+  attachCopyHandler(container);
 }
 
 function renderClaudeCodeTerminalTab(
@@ -1197,17 +1189,17 @@ function renderCoworkTab(container: HTMLElement, binaryPath: string, workerUrl: 
 }
 
 function attachCopyHandler(container: HTMLElement) {
-  const btn = container.querySelector<HTMLButtonElement>(".settings-mcp-copy-btn");
-  if (!btn) return;
-  btn.addEventListener("click", async () => {
-    const text = btn.dataset.copyText || "";
-    await navigator.clipboard.writeText(text);
-    const original = btn.textContent;
-    btn.textContent = "Copied!";
-    setTimeout(() => {
-      btn.textContent = original;
-    }, 1500);
-  });
+  for (const btn of container.querySelectorAll<HTMLButtonElement>(".settings-mcp-copy-btn")) {
+    btn.addEventListener("click", async () => {
+      const text = btn.dataset.copyText || "";
+      await navigator.clipboard.writeText(text);
+      const original = btn.textContent;
+      btn.textContent = "Copied!";
+      setTimeout(() => {
+        btn.textContent = original;
+      }, 1500);
+    });
+  }
 }
 
 async function initMcpSection() {

--- a/ui/src/sidebar.ts
+++ b/ui/src/sidebar.ts
@@ -290,17 +290,7 @@ function saveState() {
 
 export async function openFolder() {
   const path = await openDialog({ directory: true });
-  if (!path) return;
-  rootPath = path;
-  expandedDirs.clear();
-  expandedDirs.add(rootPath);
-  tagFilter = null;
-  saveState();
-  await loadTags(rootPath);
-  render();
-  refreshTree();
-  startDirWatcher();
-  onFolderChange?.(rootPath);
+  if (path) await openFolderByPath(path);
 }
 
 // --- Render ---


### PR DESCRIPTION
Closes #258

All eight items from the issue, each kept behavior-preserving:

| Area | Change |
|------|--------|
| `ui/src/main.ts` | The three tab-reload implementations (`reloadAllOpenTabs`, `reloadTabFromDisk`, the `onSwitch` disk-compare branch) now share one `applyDiskContent`/`reloadTabFromDisk` pair; `onSwitch` uses the exported `Tab` type instead of an inline shape |
| `ui/src/main.ts` | Git panel `onOpen` reuses `openFileByPath` |
| `ui/src/main.ts` startup | Welcome document is only rendered when no tab is restored — restoration triggers its own render, so the wasted parse/sanitize/morph pass is gone |
| `ui/src/sidebar.ts` | `openFolder` reduced to dialog + `openFolderByPath` |
| `ui/src/settings.ts` | New `setupResources()` shares the resource-setup + error-aggregation block between `startAutoSetup` and the Update Worker handler; `attachCopyHandler` uses `querySelectorAll` so `renderClaudeDesktopCodeTab` drops its hand-rolled copy loop |
| `src-tauri/src/commands/web.rs` | `WorkerStatus`/`HealthCapabilities` derive `Default`; `test_worker_url` error branches use struct-update syntax instead of enumerating all 11 fields; added the missing MIME-map sync comment pointing at `mcp-server-rs/src/tools.rs` |
| `src-tauri/src/main.rs` | Window-registry restore and the window-close cleanup reuse `load_window_registry`/`save_window_registry` instead of re-implementing store keys and (de)serialization |
| `src-tauri/src/bridge.rs` | Dropped the unused `_state` parameter from `git_remote_op` (3 call sites) |
| `src-tauri/src/menu.rs` | `add_recent_file` updates just the Open Recent submenu (with a whole-menu rebuild fallback) instead of rebuilding and replacing the entire native menu per file open |

Net **-56 lines**.

## Verification
- `cargo check` passes with no warnings
- `vp check src/` and `tsc --noEmit` pass