### PR TITLE
Optimize editing/scroll hot paths and Worker request latency

### DIFF
--- a/src-tauri/src/commands/editor.rs
+++ b/src-tauri/src/commands/editor.rs
@@ -5,8 +5,10 @@ use crate::error::{AppError, Result};
 
 // --- Editor State Sync ---
 
+// async: keeps the state-map lock contention off the main thread — bridge
+// handlers hold the same lock while cloning multi-MB editor content
 #[tauri::command]
-pub fn sync_editor_state(
+pub async fn sync_editor_state(
     window: tauri::Window,
     content: Option<String>,
     file_path: Option<String>,
@@ -299,8 +301,10 @@ pub struct ComrakDiagnostic {
     pub message: String,
 }
 
+// async: full-document comrak parse runs per edit (debounced linter) and
+// would block the main thread as a sync command
 #[tauri::command]
-pub fn validate_markdown(content: String) -> Result<Vec<ComrakDiagnostic>> {
+pub async fn validate_markdown(content: String) -> Result<Vec<ComrakDiagnostic>> {
     use comrak::{parse_document, Arena, Options};
 
     let arena = Arena::new();

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -158,24 +158,30 @@ fn raw_request_parts<'a>(request: &'a tauri::ipc::Request<'_>) -> Result<(String
 #[tauri::command]
 pub async fn list_directory(path: String, fold_info: Option<bool>) -> Result<Vec<FileEntry>> {
     let path = validate_path(&path)?;
-    let mut entries = read_dir_entries(&path).await?;
-    if fold_info.unwrap_or(false) {
-        for entry in entries.iter_mut().filter(|e| e.is_dir) {
-            entry.fold_chain = compute_fold_chain(&entry.path).await;
+    let fold = fold_info.unwrap_or(false);
+    // One thread-pool dispatch for the whole listing instead of one per
+    // tokio::fs call — per-entry dispatch overhead dominates on large trees
+    super::spawn_blocking(move || {
+        let mut entries = read_dir_entries(&path)?;
+        if fold {
+            for entry in entries.iter_mut().filter(|e| e.is_dir) {
+                entry.fold_chain = compute_fold_chain(&entry.path);
+            }
         }
-    }
-    Ok(entries)
+        Ok(entries)
+    })
+    .await
 }
 
 /// Walk down single-child directory chains starting at `start`.
 /// Returns the paths of successive lone child directories, or `None`
 /// when `start` contains anything other than exactly one directory.
-async fn compute_fold_chain(start: &str) -> Option<Vec<String>> {
+fn compute_fold_chain(start: &str) -> Option<Vec<String>> {
     const MAX_CHAIN: usize = 16; // guard against symlink loops
     let mut chain = Vec::new();
     let mut current = std::path::PathBuf::from(start);
     while chain.len() < MAX_CHAIN {
-        let Ok(entries) = read_dir_entries(&current).await else {
+        let Ok(entries) = read_dir_entries(&current) else {
             break;
         };
         if entries.len() != 1 || !entries[0].is_dir {
@@ -191,14 +197,19 @@ async fn compute_fold_chain(start: &str) -> Option<Vec<String>> {
 /// filtering as `list_directory`. Limits: max 20 levels deep,
 /// max 10 000 entries, skips `.git/` and `__pycache__/`.
 pub async fn list_recursive(root: &str) -> Result<Vec<FileEntry>> {
+    let root = validate_path(root)?;
+    super::spawn_blocking(move || list_recursive_sync(root)).await
+}
+
+fn list_recursive_sync(root: std::path::PathBuf) -> Result<Vec<FileEntry>> {
     const MAX_DEPTH: usize = 20;
     const MAX_ENTRIES: usize = 10_000;
 
     let mut result = Vec::new();
-    let mut stack: Vec<(std::path::PathBuf, usize)> = vec![(validate_path(root)?, 0)];
+    let mut stack: Vec<(std::path::PathBuf, usize)> = vec![(root, 0)];
 
     while let Some((dir, depth)) = stack.pop() {
-        let entries = read_dir_entries(&dir).await?;
+        let entries = read_dir_entries(&dir)?;
         for entry in entries {
             if entry.is_dir {
                 let name = entry.name.as_str();
@@ -223,22 +234,15 @@ pub async fn list_directory_recursive(path: String) -> Result<Vec<FileEntry>> {
     list_recursive(&path).await
 }
 
-async fn read_dir_entries(path: &std::path::Path) -> Result<Vec<FileEntry>> {
-    let mut entries = Vec::new();
-    let mut read_dir = tokio::fs::read_dir(path)
-        .await
+fn read_dir_entries(path: &std::path::Path) -> Result<Vec<FileEntry>> {
+    let read_dir = std::fs::read_dir(path)
         .map_err(|e| AppError::Io(format!("Failed to read directory: {e}")))?;
 
-    while let Some(entry) = read_dir
-        .next_entry()
-        .await
-        .map_err(|e| AppError::Io(e.to_string()))?
-    {
+    let mut entries = Vec::new();
+    for entry in read_dir {
+        let entry = entry.map_err(|e| AppError::Io(e.to_string()))?;
         let name = entry.file_name().to_string_lossy().to_string();
-        let file_type = entry
-            .file_type()
-            .await
-            .map_err(|e| AppError::Io(e.to_string()))?;
+        let file_type = entry.file_type().map_err(|e| AppError::Io(e.to_string()))?;
         let entry_path = entry.path();
         let extension = entry_path
             .extension()
@@ -247,7 +251,6 @@ async fn read_dir_entries(path: &std::path::Path) -> Result<Vec<FileEntry>> {
 
         let modified_at = entry
             .metadata()
-            .await
             .ok()
             .and_then(|m| m.modified().ok())
             .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())

--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -2,6 +2,7 @@ use serde::Serialize;
 use std::process::Command;
 use std::sync::{LazyLock, Mutex};
 
+use super::spawn_blocking;
 use crate::error::{AppError, Result};
 
 // --- CLI Command Runner ---
@@ -83,13 +84,6 @@ fn run_git_unlocked(repo_path: &str, args: &[&str]) -> Result<String> {
     let mut full_args = vec!["-C", repo_path];
     full_args.extend_from_slice(args);
     run_cli("git", &full_args)
-}
-
-/// Run a blocking closure on the tokio thread pool, mapping join errors.
-async fn spawn_blocking<T: Send + 'static>(
-    f: impl FnOnce() -> Result<T> + Send + 'static,
-) -> Result<T> {
-    tokio::task::spawn_blocking(f).await?
 }
 
 #[derive(Serialize)]

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -15,6 +15,13 @@ use tauri_plugin_store::StoreExt;
 
 use crate::error::{AppError, Result};
 
+/// Run a blocking closure on the tokio thread pool, mapping join errors.
+pub(crate) async fn spawn_blocking<T: Send + 'static>(
+    f: impl FnOnce() -> Result<T> + Send + 'static,
+) -> Result<T> {
+    tokio::task::spawn_blocking(f).await?
+}
+
 // --- Shared Editor State (for MCP bridge) ---
 
 #[derive(Clone, Serialize, Deserialize, Default)]

--- a/src-tauri/src/commands/web.rs
+++ b/src-tauri/src/commands/web.rs
@@ -52,7 +52,7 @@ pub(crate) async fn worker_request<T: DeserializeOwned + HasWorkerError>(
 // --- Worker Health Check ---
 
 /// Must match WORKER_VERSION in worker/src/config.ts.
-const EXPECTED_WORKER_VERSION: u32 = 10;
+const EXPECTED_WORKER_VERSION: u32 = 11;
 
 #[derive(Serialize, Default)]
 pub struct WorkerStatus {

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -194,6 +194,9 @@ function flushPendingContent(): string | null {
 
 setTabContentFlusher(flushPendingContent);
 
+// Skip preview rendering while the preview pane is collapsed; render once on expand
+let previewDirty = false;
+
 const updatePreviewListener = EditorView.updateListener.of((update) => {
   if (update.docChanged) {
     scrollState.pendingRender = true;
@@ -202,7 +205,11 @@ const updatePreviewListener = EditorView.updateListener.of((update) => {
     previewTimeout = setTimeout(() => {
       previewTimeout = null;
       const content = flushPendingContent() ?? editor.state.doc.toString();
-      renderPreview(content);
+      if (previewWrapper.classList.contains("collapsed")) {
+        previewDirty = true;
+      } else {
+        renderPreview(content);
+      }
       updateFrontmatterPanel(content);
       updateTocPanel(content);
       updateStatus(editor.state);
@@ -829,6 +836,10 @@ function togglePreview() {
   previewUnfoldBtn.classList.toggle("visible", collapsed);
   updateDividerVisibility();
   setStorageBool(windowKey(KEY_PREVIEW_COLLAPSED), collapsed);
+  if (!collapsed && previewDirty) {
+    previewDirty = false;
+    renderPreview(flushPendingContent() ?? editor.state.doc.toString());
+  }
 }
 
 sidebarUnfoldBtn.addEventListener("click", toggleSidebar);

--- a/ui/src/markdown-lint.ts
+++ b/ui/src/markdown-lint.ts
@@ -29,10 +29,18 @@ export interface LintDiagnostic {
   message: string;
 }
 
+// Single-entry memo — the CodeMirror linter and the MCP sync both lint the
+// same text; offsets are identical for both callers. Returns a copy because
+// the linter appends comrak diagnostics to the result.
+let lastCheckText: string | null = null;
+let lastCheckResult: Diagnostic[] = [];
+
 function runAllChecks(
   text: string,
   doc: { line: (n: number) => { from: number; to: number; text: string } },
 ): Diagnostic[] {
+  if (text === lastCheckText) return lastCheckResult.slice();
+
   const lines = text.split("\n");
   const structure = getDocumentStructure(text);
   const diagnostics: Diagnostic[] = [];
@@ -48,7 +56,9 @@ function runAllChecks(
   checkHtmlComments(lines, structure.codeRanges, doc, diagnostics);
   checkBlankLines(lines, structure.codeRanges, doc, diagnostics, structure);
 
-  return diagnostics;
+  lastCheckText = text;
+  lastCheckResult = diagnostics;
+  return diagnostics.slice();
 }
 
 export function getLintDiagnostics(text: string): LintDiagnostic[] {

--- a/ui/src/preview-render.ts
+++ b/ui/src/preview-render.ts
@@ -488,7 +488,16 @@ export async function renderPreview(source: string) {
         if (oldNode.classList.contains("inline-svg")) {
           return false;
         }
+        // Keep the copy-btn marker so the post-render pass skips already-done PREs
+        if (oldNode.tagName === "PRE" && oldNode.dataset.copyBtn) {
+          newNode.dataset.copyBtn = "true";
+        }
         return true;
+      },
+      beforeNodeRemoved(node: Node) {
+        // Copy buttons are added post-render and absent from the new HTML —
+        // keep them instead of recreating button + listener on every render
+        return !(node instanceof HTMLElement && node.classList.contains("code-copy-btn"));
       },
     },
   });

--- a/ui/src/scroll-sync.ts
+++ b/ui/src/scroll-sync.ts
@@ -12,6 +12,9 @@ export const scrollState = {
   activeSide: "editor" as "editor" | "preview",
   syncRAF: 0,
   cachedSourceLineEls: [] as HTMLElement[],
+  // Parsed source-line numbers parallel to cachedSourceLineEls (DOM order,
+  // monotonically non-decreasing) — enables binary search in sync functions
+  cachedSourceLines: [] as number[],
 };
 
 let editor: EditorView;
@@ -49,24 +52,45 @@ function getCodeBlockLineInfo(preEl: HTMLElement) {
 
 // --- Helpers for finding surrounding data-source-line elements ---
 
-function findSurroundingEls(elements: HTMLElement[], targetLine: number) {
-  let before: HTMLElement | null = null;
-  let after: HTMLElement | null = null;
-  let beforeLine = -1;
-  let afterLine = Infinity;
+function findSurroundingEls(targetLine: number) {
+  const elements = scrollState.cachedSourceLineEls;
+  const lines = scrollState.cachedSourceLines;
+  if (elements.length === 0) return null;
 
-  for (const el of elements) {
-    const sl = parseInt(el.dataset.sourceLine!, 10);
-    if (isNaN(sl)) continue;
-    if (sl <= targetLine && sl > beforeLine) {
-      before = el;
-      beforeLine = sl;
-    }
-    if (sl >= targetLine && sl < afterLine) {
-      after = el;
-      afterLine = sl;
+  // Binary search: last index with line <= targetLine
+  let lo = 0;
+  let hi = elements.length - 1;
+  let beforeIdx = -1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    if (lines[mid] <= targetLine) {
+      beforeIdx = mid;
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
     }
   }
+  // First element among equal-line duplicates
+  while (beforeIdx > 0 && lines[beforeIdx - 1] === lines[beforeIdx]) beforeIdx--;
+
+  // Binary search: first index with line >= targetLine
+  lo = 0;
+  hi = elements.length - 1;
+  let afterIdx = -1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    if (lines[mid] >= targetLine) {
+      afterIdx = mid;
+      hi = mid - 1;
+    } else {
+      lo = mid + 1;
+    }
+  }
+
+  let before: HTMLElement | null = beforeIdx >= 0 ? elements[beforeIdx] : null;
+  let after: HTMLElement | null = afterIdx >= 0 ? elements[afterIdx] : null;
+  let beforeLine = beforeIdx >= 0 ? lines[beforeIdx] : -1;
+  let afterLine = afterIdx >= 0 ? lines[afterIdx] : Infinity;
 
   if (!before && !after) return null;
   if (!before) {
@@ -128,9 +152,16 @@ function computePreviewY(
 
 export function buildScrollAnchors() {
   // Refresh cached source-line elements (used by all sync functions)
-  scrollState.cachedSourceLineEls = Array.from(
-    previewPane.querySelectorAll("[data-source-line]"),
-  ) as HTMLElement[];
+  const els: HTMLElement[] = [];
+  const lines: number[] = [];
+  for (const el of previewPane.querySelectorAll("[data-source-line]")) {
+    const sl = parseInt((el as HTMLElement).dataset.sourceLine!, 10);
+    if (isNaN(sl)) continue;
+    els.push(el as HTMLElement);
+    lines.push(sl);
+  }
+  scrollState.cachedSourceLineEls = els;
+  scrollState.cachedSourceLines = lines;
 }
 
 // --- Viewport-based scroll sync ---
@@ -171,7 +202,7 @@ export function syncToPreview() {
   const editorSubOffset = cmScroller.scrollTop - topBlock.top;
   const blockProgress = topBlock.height > 0 ? editorSubOffset / topBlock.height : 0;
 
-  const surr = findSurroundingEls(elements, topLine);
+  const surr = findSurroundingEls(topLine);
   if (!surr) return;
 
   const previewY = computePreviewY(surr, topLine);
@@ -228,10 +259,11 @@ export function syncToEditor() {
     }
   }
 
+  const lines = scrollState.cachedSourceLines;
   let before: HTMLElement | null = beforeIdx >= 0 ? elements[beforeIdx] : null;
   let after: HTMLElement | null = beforeIdx + 1 < elements.length ? elements[beforeIdx + 1] : null;
-  let beforeLine = before ? parseInt(before.dataset.sourceLine!, 10) : -1;
-  let afterLine = after ? parseInt(after.dataset.sourceLine!, 10) : Infinity;
+  let beforeLine = beforeIdx >= 0 ? lines[beforeIdx] : -1;
+  let afterLine = beforeIdx + 1 < elements.length ? lines[beforeIdx + 1] : Infinity;
   let beforeAbsY = before ? getAbsY(before) : -Infinity;
   let afterAbsY = after ? getAbsY(after) : Infinity;
 
@@ -355,7 +387,7 @@ export function syncPreviewToCursor() {
   const elements = scrollState.cachedSourceLineEls;
   if (elements.length === 0) return;
 
-  const surr = findSurroundingEls(elements, cursorLine);
+  const surr = findSurroundingEls(cursorLine);
   if (!surr) return;
 
   const previewTargetY = computePreviewY(surr, cursorLine);

--- a/ui/src/toc-panel.ts
+++ b/ui/src/toc-panel.ts
@@ -10,6 +10,7 @@ let editor: EditorView;
 let collapsed = true;
 let lastHeadings: Heading[] = [];
 let lastContent: string | null = null;
+let lastActiveIdx = -2;
 
 export function initTocPanel(ed: EditorView, container: HTMLElement) {
   editor = ed;
@@ -95,6 +96,7 @@ function render() {
   }
 
   panelEl.innerHTML = html;
+  lastActiveIdx = -2;
 }
 
 /** Highlight the heading closest to the current editor viewport. */
@@ -115,6 +117,10 @@ export function updateTocActiveHeading() {
   }
   // If no heading before viewport, highlight first
   if (activeIdx === -1 && lastHeadings.length > 0) activeIdx = 0;
+
+  // Skip DOM updates when the active heading hasn't changed (scroll hot path)
+  if (activeIdx === lastActiveIdx) return;
+  lastActiveIdx = activeIdx;
 
   const items = panelEl.querySelectorAll(".toc-item");
   for (let i = 0; i < items.length; i++) {

--- a/worker/src/config.ts
+++ b/worker/src/config.ts
@@ -1,5 +1,5 @@
 // Bump this when adding/changing endpoints so the app can detect outdated Workers.
-export const WORKER_VERSION = 10;
+export const WORKER_VERSION = 11;
 
 // --- Cache TTLs (seconds) ---
 export const RENDER_CACHE_TTL = 3600; // 1 hour

--- a/worker/src/handlers/crawl.ts
+++ b/worker/src/handlers/crawl.ts
@@ -1,6 +1,6 @@
 import type { Env } from "../types.js";
 import { CRAWL_LIMIT_MAX, CRAWL_LIMIT_DEFAULT, CRAWL_DEPTH_DEFAULT } from "../config.js";
-import { jsonResponse, parseJsonBody, hasSecrets, wrapJsonSchema } from "../utils.js";
+import { jsonResponse, parseJsonBody, hasSecrets, wrapJsonSchema, CORS_HEADERS } from "../utils.js";
 import { validateUrlForSsrf } from "../ssrf.js";
 
 export async function handleCrawlStart(request: Request, env: Env): Promise<Response> {
@@ -115,8 +115,11 @@ export async function handleCrawlStatus(jobId: string, url: URL, env: Env): Prom
       return jsonResponse({ error: `Crawl status API error (${response.status}): ${errorBody}` }, response.status);
     }
 
-    const data = await response.json();
-    return jsonResponse(data);
+    // Stream the upstream body through — results can be many MB of markdown,
+    // buffering + re-serializing them just to add CORS headers wastes CPU/memory
+    return new Response(response.body, {
+      headers: { ...CORS_HEADERS, "content-type": "application/json" },
+    });
   } catch (e) {
     return jsonResponse({ error: `Crawl status failed: ${e instanceof Error ? e.message : String(e)}` }, 500);
   }

--- a/worker/src/handlers/fetch.ts
+++ b/worker/src/handlers/fetch.ts
@@ -3,7 +3,7 @@ import { FETCH_KV_TTL } from "../config.js";
 import { jsonResponse, parseJsonBody, sha256, shouldBypassCache, kvGet, kvPut, htmlToMarkdown, detectSpa } from "../utils.js";
 import { validateUrlForSsrf } from "../ssrf.js";
 
-export async function handleFetch(request: Request, env: Env): Promise<Response> {
+export async function handleFetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
   const body = await parseJsonBody<{ url: string }>(request);
   if (body instanceof Response) return body;
 
@@ -43,7 +43,7 @@ export async function handleFetch(request: Request, env: Env): Promise<Response>
     if (contentType.includes("text/markdown")) {
       const markdown = await response.text();
       const result = { markdown, source: "markdown-for-agents", spa_detected: false };
-      await kvPut(env, cacheKey, JSON.stringify(result), FETCH_KV_TTL, { url: body.url, endpoint: "fetch" });
+      ctx.waitUntil(kvPut(env, cacheKey, JSON.stringify(result), FETCH_KV_TTL, { url: body.url, endpoint: "fetch" }));
       return jsonResponse({ ...result, cache: "miss" });
     }
 
@@ -52,7 +52,7 @@ export async function handleFetch(request: Request, env: Env): Promise<Response>
     const spaDetected = detectSpa(html);
     const markdown = await htmlToMarkdown(html, env);
     const result = { markdown, source: "ai-to-markdown", spa_detected: spaDetected };
-    await kvPut(env, cacheKey, JSON.stringify(result), FETCH_KV_TTL, { url: body.url, endpoint: "fetch" });
+    ctx.waitUntil(kvPut(env, cacheKey, JSON.stringify(result), FETCH_KV_TTL, { url: body.url, endpoint: "fetch" }));
     return jsonResponse({ ...result, cache: "miss" });
   } catch (e) {
     return jsonResponse({ error: `Fetch failed: ${e instanceof Error ? e.message : String(e)}` }, 500);

--- a/worker/src/handlers/publish.ts
+++ b/worker/src/handlers/publish.ts
@@ -65,8 +65,7 @@ export async function handleServePublished(key: string, env: Env): Promise<Respo
     return new Response("Gone — this content has expired", { status: 410, headers: CORS_HEADERS });
   }
 
-  const markdown = await obj.text();
-  return new Response(markdown, {
+  return new Response(obj.body, {
     headers: {
       ...CORS_HEADERS,
       "content-type": "text/markdown; charset=utf-8",

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -23,7 +23,7 @@ export default {
     }
 
     if (request.method === "POST" && url.pathname === "/fetch") {
-      return handleFetch(request, env);
+      return handleFetch(request, env, ctx);
     }
 
     if (request.method === "GET" && url.pathname === "/render") {

--- a/worker/src/ssrf.ts
+++ b/worker/src/ssrf.ts
@@ -65,6 +65,13 @@ async function resolveHostname(hostname: string): Promise<string[]> {
   return [...v4, ...v6];
 }
 
+// Short-lived per-isolate cache of DNS-based verdicts — avoids paying two
+// DoH round trips per request when the same host is fetched repeatedly
+// (crawls, batch link fetching). TTL keeps DNS-rebinding exposure bounded.
+const VERDICT_TTL_MS = 60_000;
+const VERDICT_CACHE_MAX = 256;
+const verdictCache = new Map<string, { verdict: string | null; expires: number }>();
+
 export async function validateUrlForSsrf(input: string): Promise<string | null> {
   let parsed: URL;
   try {
@@ -82,12 +89,21 @@ export async function validateUrlForSsrf(input: string): Promise<string | null> 
     return "Blocked: URL resolves to a private/reserved IP address";
   }
 
+  const cached = verdictCache.get(hostname);
+  if (cached && cached.expires > Date.now()) {
+    return cached.verdict;
+  }
+
   const ips = await resolveHostname(hostname);
+  let verdict: string | null = null;
   for (const ip of ips) {
     if (isPrivateIp(ip)) {
-      return "Blocked: URL resolves to a private/reserved IP address";
+      verdict = "Blocked: URL resolves to a private/reserved IP address";
+      break;
     }
   }
 
-  return null;
+  if (verdictCache.size >= VERDICT_CACHE_MAX) verdictCache.clear();
+  verdictCache.set(hostname, { verdict, expires: Date.now() + VERDICT_TTL_MS });
+  return verdict;
 }


### PR DESCRIPTION
Closes #278

Performance-focused review across the frontend, Tauri backend, and Worker. All changes are small and behavior-preserving; each targets work that runs per keystroke, per scroll frame, or per request.

## Frontend (ui/src)

- **scroll-sync.ts** — `buildScrollAnchors` now caches parsed source-line numbers alongside the elements, and `findSurroundingEls` uses binary search (O(log N)) instead of scanning every `[data-source-line]` element with `dataset` access + `parseInt` per scroll frame (up to 60 Hz) and per cursor move. `syncToEditor` already used binary search on the same monotonic ordering; this makes both directions symmetric.
- **main.ts** — the debounced update no longer runs the full render pipeline (CJK emphasis regexes → marked → DOMPurify → Idiomorph → post-render) while the preview pane is collapsed. A dirty flag triggers a single render when the pane is expanded again.
- **markdown-lint.ts** — single-entry memo for `runAllChecks`; the CodeMirror linter (500 ms debounce) and MCP sync (2 s debounce) lint identical text, and `checkEmphasis` calls `marked.parseInline` per candidate match, so each text now pays that cost once.
- **preview-render.ts** — Idiomorph callbacks now preserve code-block copy buttons and their `data-copy-btn` markers, instead of destroying and recreating button + listener for every `<pre>` on every render (up to 10 Hz while typing).
- **toc-panel.ts** — `updateTocActiveHeading` returns early when the active heading index is unchanged, skipping `querySelectorAll`, N × `classList.toggle`, and two `getBoundingClientRect` calls per scroll frame.

## Tauri backend (src-tauri)

- **editor.rs** — `validate_markdown` and `sync_editor_state` are now `async`, moving them off the main thread. The comrak full-document parse runs on every edit via the debounced linter and could block the UI thread on large documents.
- **files.rs** — directory listing now uses `std::fs` inside a single `spawn_blocking` call instead of per-entry `tokio::fs` dispatches (`list_recursive` could dispatch ~10,000 times per sidebar refresh). The `spawn_blocking` helper moved from git.rs to commands/mod.rs for reuse.

## Worker (v10 → v11)

- **fetch.ts** — KV cache writes are deferred with `ctx.waitUntil` instead of blocking the response (matches the existing pattern in render.ts).
- **ssrf.ts** — 60 s per-isolate cache of DNS-based SSRF verdicts per hostname; previously every uncached `/fetch`, `/render`, `/json`, and `/crawl` request paid two DNS-over-HTTPS round trips before starting real work. The short TTL keeps DNS-rebinding exposure bounded, and literal-IP checks still run on every request.
- **crawl.ts / publish.ts** — `/crawl/:id` streams the upstream body through instead of `JSON.parse` + re-stringify of potentially multi-MB payloads just to add CORS headers; `/p/:key` streams the R2 object instead of buffering it.

## Verification

- `cargo check` — clean (one pre-existing warning in mcp-server-rs, untouched)
- `vp check src/` — format + lint pass
- `tsc --noEmit` — clean for both `ui/` and `worker/`

## Noted but deferred (in #278 scope, larger changes)

- `GIT_LOCK` held across network-bound push/pull/fetch (blocks `git_status`, causes MCP 5 s timeouts)
- MCP `list_directory` serializing up to 10,000 entries before client-side truncation
- Sidebar full-tree re-render on single folder toggle